### PR TITLE
feat: date-driven auto-expiring New badges on homepage tiles

### DIFF
--- a/src/components/TileEyebrow.astro
+++ b/src/components/TileEyebrow.astro
@@ -7,24 +7,23 @@
  * renders "New · Aug 17 · Method" in the accent tone; after that it
  * renders the category alone in the secondary tone. The comparison runs
  * at build time — the hourly radar auto-update push rebuilds the site,
- * so the badge expires without anyone editing a label.
+ * so the badge expires without anyone editing a label. The derivation
+ * itself lives in src/lib/eyebrow.ts, where tests can inject a clock.
  *
  * Props:
  *   added     — the page's ship date, ISO yyyy-mm-dd (read from git:
  *               `git log --diff-filter=A --follow --format=%as -- <page>`).
  *   category  — the permanent label (e.g. "Method", "Reference").
  */
+import { eyebrowLabel } from '@/lib/eyebrow';
+
 interface Props {
   added: string;
   category: string;
 }
 const { added, category } = Astro.props;
-
-const NEW_WINDOW_DAYS = 30;
-const shipped = Date.parse(added + 'T00:00:00Z');
-const isNew = Date.now() - shipped < NEW_WINDOW_DAYS * 86_400_000;
-const when = new Date(shipped).toLocaleDateString('en-US', { month: 'short', day: 'numeric', timeZone: 'UTC' });
+const { text, isNew } = eyebrowLabel(added, category);
 ---
 <div class="text-xs uppercase tracking-wider mb-2" style={`color: rgb(var(${isNew ? '--accent' : '--accent-2'}))`}>
-  {isNew ? `New · ${when} · ${category}` : category}
+  {text}
 </div>

--- a/src/components/TileEyebrow.astro
+++ b/src/components/TileEyebrow.astro
@@ -1,0 +1,30 @@
+---
+/**
+ * TileEyebrow — the eyebrow label on a homepage tile, with a New badge
+ * that derives from the page's ship date instead of being hand-typed.
+ *
+ * While `added` is within NEW_WINDOW_DAYS of the build date the eyebrow
+ * renders "New · Aug 17 · Method" in the accent tone; after that it
+ * renders the category alone in the secondary tone. The comparison runs
+ * at build time — the hourly radar auto-update push rebuilds the site,
+ * so the badge expires without anyone editing a label.
+ *
+ * Props:
+ *   added     — the page's ship date, ISO yyyy-mm-dd (read from git:
+ *               `git log --diff-filter=A --follow --format=%as -- <page>`).
+ *   category  — the permanent label (e.g. "Method", "Reference").
+ */
+interface Props {
+  added: string;
+  category: string;
+}
+const { added, category } = Astro.props;
+
+const NEW_WINDOW_DAYS = 30;
+const shipped = Date.parse(added + 'T00:00:00Z');
+const isNew = Date.now() - shipped < NEW_WINDOW_DAYS * 86_400_000;
+const when = new Date(shipped).toLocaleDateString('en-US', { month: 'short', day: 'numeric', timeZone: 'UTC' });
+---
+<div class="text-xs uppercase tracking-wider mb-2" style={`color: rgb(var(${isNew ? '--accent' : '--accent-2'}))`}>
+  {isNew ? `New · ${when} · ${category}` : category}
+</div>

--- a/src/lib/eyebrow.ts
+++ b/src/lib/eyebrow.ts
@@ -1,0 +1,23 @@
+// Label derivation for homepage tile eyebrows (TileEyebrow.astro).
+// Lives here rather than in the component so the expiry rule is testable
+// with an injected clock — .astro frontmatter can't be imported by node:test.
+// Covered by tests/eyebrow.test.mjs.
+
+export const NEW_WINDOW_DAYS = 30;
+
+export function eyebrowLabel(
+  added: string,
+  category: string,
+  now: number = Date.now(),
+): { text: string; isNew: boolean } {
+  const shipped = Date.parse(added + 'T00:00:00Z');
+  if (Number.isNaN(shipped)) {
+    // Fail the build, not the badge: a silent parse failure would render the
+    // tile as merely not-new, which is invisible on the page that needs it.
+    throw new Error(`eyebrowLabel: invalid added date "${added}" — expected ISO yyyy-mm-dd`);
+  }
+  const isNew = now - shipped < NEW_WINDOW_DAYS * 86_400_000;
+  if (!isNew) return { text: category, isNew };
+  const when = new Date(shipped).toLocaleDateString('en-US', { month: 'short', day: 'numeric', timeZone: 'UTC' });
+  return { text: `New · ${when} · ${category}`, isNew };
+}

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -5,6 +5,7 @@ import HeroIntro from '@/widgets/HeroIntro.tsx';
 import ResumeReading from '@/widgets/ResumeReading.tsx';
 import CommandPaletteMount from '@/components/CommandPaletteMount.astro';
 import ManifestoQuote from '@/components/ManifestoQuote.astro';
+import TileEyebrow from '@/components/TileEyebrow.astro';
 import { CHANGELOG } from '@/lib/changelog';
 import { SETUP_STATS } from '@/lib/setup';
 const base = import.meta.env.BASE_URL.replace(/\/$/, '');
@@ -115,7 +116,7 @@ const edWhen = new Date(ed.date + 'T00:00:00Z').toLocaleDateString('en-US', { mo
   <section class="container-wide pt-6 pb-24">
     <div class="grid gap-6 md:grid-cols-2 lg:grid-cols-4">
       <a href={`${base}/radar/`} class="card hover:border-flame no-underline" style="color: rgb(var(--fg))">
-        <div class="text-xs uppercase tracking-wider mb-2" style="color: rgb(var(--accent-2))">New · Live · Updated hourly</div>
+        <TileEyebrow added="2026-06-13" category="Live · Updated hourly" />
         <h3 class="m-0 font-display text-2xl">Radar — what's moving in AI, ranked by lead time</h3>
         <p class="mt-2 text-sm" style="color: rgb(var(--muted))">A self-updating index of what's travelling through the AI ecosystem, ranked by where it sits on the gradient — papers to repos to community to analysis. The receipts are on every row. See it before the crowd does.</p>
       </a>
@@ -125,138 +126,138 @@ const edWhen = new Date(ed.date + 'T00:00:00Z').toLocaleDateString('en-US', { mo
         <p class="mt-2 text-sm" style="color: rgb(var(--muted))">New to AI, Claude, Claude Code, or Cowork? The official free courses in the right order, a five-word primer, and the learning ladder — then the book.</p>
       </a>
       <a href={`${base}/agent-workflow/`} class="card hover:border-flame no-underline" style="color: rgb(var(--fg))">
-        <div class="text-xs uppercase tracking-wider mb-2" style="color: rgb(var(--accent))">New · Method</div>
+        <TileEyebrow added="2026-08-17" category="Method" />
         <h3 class="m-0 font-display text-2xl">Agent workflow</h3>
         <p class="mt-2 text-sm" style="color: rgb(var(--muted))">The agent doesn't pick what to work on — the board does. Sixteen repos, one queue, three slash commands, six review agents that wake by file path. The whole setup: boards, issue discipline, the review fleet, every option judged, and the four things that blew up installing it.</p>
       </a>
       <a href={`${base}/terminal-setup/`} class="card hover:border-flame no-underline" style="color: rgb(var(--fg))">
-        <div class="text-xs uppercase tracking-wider mb-2" style="color: rgb(var(--accent))">New · Setup</div>
+        <TileEyebrow added="2026-08-17" category="Setup" />
         <h3 class="m-0 font-display text-2xl">Fleet paint</h3>
         <p class="mt-2 text-sm" style="color: rgb(var(--muted))">Six agents, six identical black windows — until you paint them. Statusline, OSC escape codes, and a watcher that colors every terminal by project. The full setup, built by Claude Code, with the gotchas that cost a day.</p>
       </a>
       <a href={`${base}/cad-as-code/`} class="card hover:border-flame no-underline" style="color: rgb(var(--fg))">
-        <div class="text-xs uppercase tracking-wider mb-2" style="color: rgb(var(--accent))">New · Hardware</div>
+        <TileEyebrow added="2026-08-03" category="Hardware" />
         <h3 class="m-0 font-display text-2xl">CAD-as-code</h3>
         <p class="mt-2 text-sm" style="color: rgb(var(--muted))">Claude designed a 3D-printable museum frame for the bird station's 13.3" e-ink panel — eight parts as STL + STEP, emitted by 267 lines of Python whose dimensions were read off the vendor's drawing. The six mechanical decisions, the self-QA harness, and the honest part: zero grams printed until the calipers agree.</p>
       </a>
       <a href={`${base}/opus-5/`} class="card hover:border-flame no-underline" style="color: rgb(var(--fg))">
-        <div class="text-xs uppercase tracking-wider mb-2" style="color: rgb(var(--accent))">New · Model file · Jul 24</div>
+        <TileEyebrow added="2026-07-27" category="Model file" />
         <h3 class="m-0 font-display text-2xl">Opus 5 — the frontier stopped being the expensive one</h3>
         <p class="mt-2 text-sm" style="color: rgb(var(--muted))">On the independent Intelligence Index, the top model is no longer the priciest per task — Opus 5 took first place below the cost of the model beneath it. (Anthropic still points to Fable 5 for highest available capability.) The effort dial, the hierarchy question, and <span style="color: rgb(var(--accent))">seven jobs with the setting for each</span> — including one where turning the dial up makes it worse.</p>
       </a>
       <a href={`${base}/fable-5/`} class="card hover:border-flame no-underline" style="color: rgb(var(--fg))">
-        <div class="text-xs uppercase tracking-wider mb-2" style="color: rgb(var(--accent-2))">Model file</div>
+        <TileEyebrow added="2026-06-09" category="Model file" />
         <h3 class="m-0 font-display text-2xl">Fable 5 — the withheld model, buyable</h3>
         <p class="mt-2 text-sm" style="color: rgb(var(--muted))">Anthropic shipped the model it said it wouldn't — split in two. Pricing, the full benchmark table read honestly, the fallback architecture, and the June 22 clock.</p>
       </a>
       <a href={`${base}/music-is-math/`} class="card hover:border-flame no-underline" style="color: rgb(var(--fg))">
-        <div class="text-xs uppercase tracking-wider mb-2" style="color: rgb(var(--accent))">New · Foundations</div>
+        <TileEyebrow added="2026-07-30" category="Foundations" />
         <h3 class="m-0 font-display text-2xl">Music is math</h3>
         <p class="mt-2 text-sm" style="color: rgb(var(--muted))">How AI actually writes a song — 44,100 numbers a second become a few hundred symbols, and a transformer finishes the sentence. Then the same recipe goes and writes proteins, drives robot arms, and beats the world's best weather forecast. Includes the three places the story is oversold, and the five claims my own draft got wrong.</p>
       </a>
       <a href={`${base}/dynamic-workflows/`} class="card hover:border-flame no-underline" style="color: rgb(var(--fg))">
-        <div class="text-xs uppercase tracking-wider mb-2" style="color: rgb(var(--accent))">Dynamic Workflows</div>
+        <TileEyebrow added="2026-05-30" category="Dynamic Workflows" />
         <h3 class="m-0 font-display text-2xl">Opus 4.8 — the swarm that runs itself</h3>
         <p class="mt-2 text-sm" style="color: rgb(var(--muted))">Claude writes a script that plans, fans out hundreds of parallel subagents, and verifies its own work. What it is, the validator loop, how to turn it on, and when not to.</p>
       </a>
       <a href={`${base}/good-taste/`} class="card hover:border-flame no-underline" style="color: rgb(var(--fg))">
-        <div class="text-xs uppercase tracking-wider mb-2" style="color: rgb(var(--accent))">New · Showcase</div>
+        <TileEyebrow added="2026-06-16" category="Showcase" />
         <h3 class="m-0 font-display text-2xl">Good taste, on tap</h3>
         <p class="mt-2 text-sm" style="color: rgb(var(--muted))">Stop your AI from generating generic slop. A before/after of Leon Lin's public taste-skill (45k★, credited) — and the moon-base and three-design receipts I built with the discipline.</p>
       </a>
       {/* [VLAD: h3 + hook below are candidates from the design swarm — confirm/revoice. Links to the new /dreaming page (Ch 44's sibling).] */}
       <a href={`${base}/dreaming/`} class="card hover:border-flame no-underline" style="color: rgb(var(--fg))">
-        <div class="text-xs uppercase tracking-wider mb-2" style="color: rgb(var(--accent))">Memory</div>
+        <TileEyebrow added="2026-06-04" category="Memory" />
         <h3 class="m-0 font-display text-2xl">Dreaming — the loop pointed inward</h3>
         <p class="mt-2 text-sm" style="color: rgb(var(--muted))">A local, propose-only twin of Anthropic's Dreaming: it digests your sessions, surfaces candidate memories that each cite a verbatim quote, and re-verifies every one against the raw transcript — and never writes to memory itself.</p>
       </a>
       <a href={`${base}/self-audit/`} class="card hover:border-flame no-underline" style="color: rgb(var(--fg))">
-        <div class="text-xs uppercase tracking-wider mb-2" style="color: rgb(var(--accent))">New · Method</div>
+        <TileEyebrow added="2026-06-09" category="Method" />
         <h3 class="m-0 font-display text-2xl">The Self-Audit</h3>
         <p class="mt-2 text-sm" style="color: rgb(var(--muted))">The swarm pointed at the agent's own setup. Five auditors, an adversarial red-team, 41 findings — including two refutations that would have broken the system if executed. Your config rots faster than your code.</p>
       </a>
       <a href={`${base}/claude-code-pricing/`} class="card hover:border-flame no-underline" style="color: rgb(var(--fg))">
-        <div class="text-xs uppercase tracking-wider mb-2" style="color: rgb(var(--accent-2))">New · Reference</div>
+        <TileEyebrow added="2026-06-10" category="Reference" />
         <h3 class="m-0 font-display text-2xl">What Claude Code actually costs</h3>
         <p class="mt-2 text-sm" style="color: rgb(var(--muted))">Every plan and API rate, verified — then the receipts: the real monthly bill, the $1,108→$4,312 cache mistake, and the three levers that cut it.</p>
       </a>
       <a href={`${base}/claude-code-vs-codex/`} class="card hover:border-flame no-underline" style="color: rgb(var(--fg))">
-        <div class="text-xs uppercase tracking-wider mb-2" style="color: rgb(var(--accent-2))">New · Comparison</div>
+        <TileEyebrow added="2026-06-10" category="Comparison" />
         <h3 class="m-0 font-display text-2xl">Claude Code vs Codex</h3>
         <p class="mt-2 text-sm" style="color: rgb(var(--muted))">Ran both in anger. Verdict per job — including the night shift Codex actually wins.</p>
       </a>
       <a href={`${base}/claude-code-hooks/`} class="card hover:border-flame no-underline" style="color: rgb(var(--fg))">
-        <div class="text-xs uppercase tracking-wider mb-2" style="color: rgb(var(--accent-2))">New · Reference</div>
+        <TileEyebrow added="2026-06-10" category="Reference" />
         <h3 class="m-0 font-display text-2xl">Hooks that can't be talked out of</h3>
         <p class="mt-2 text-sm" style="color: rgb(var(--muted))">Ten real configs with verdicts — what each caught in production, and the three hook ideas that failed expensively.</p>
       </a>
       <a href={`${base}/claude-code-mcp/`} class="card hover:border-flame no-underline" style="color: rgb(var(--fg))">
-        <div class="text-xs uppercase tracking-wider mb-2" style="color: rgb(var(--accent-2))">New · Setup</div>
+        <TileEyebrow added="2026-06-10" category="Setup" />
         <h3 class="m-0 font-display text-2xl">Claude Code + MCP</h3>
         <p class="mt-2 text-sm" style="color: rgb(var(--muted))">The setup guide grounded in a real roster: the servers worth wiring, what each one costs and earns, and the ones that got cut.</p>
       </a>
       <a href={`${base}/ai-agent-examples/`} class="card hover:border-flame no-underline" style="color: rgb(var(--fg))">
-        <div class="text-xs uppercase tracking-wider mb-2" style="color: rgb(var(--accent-2))">New · Examples</div>
+        <TileEyebrow added="2026-06-10" category="Examples" />
         <h3 class="m-0 font-display text-2xl">12 agents that actually ran</h3>
         <p class="mt-2 text-sm" style="color: rgb(var(--muted))">A receipts gallery: the book swarm, the 4 AM watcher, the $0.40/min voice agent — every example with a cost and a failure on record.</p>
       </a>
       <a href={`${base}/sovereign-stack/`} class="card hover:border-flame no-underline" style="color: rgb(var(--fg))">
-        <div class="text-xs uppercase tracking-wider mb-2" style="color: rgb(var(--accent))">Sovereign Stack</div>
+        <TileEyebrow added="2026-05-20" category="Sovereign Stack" />
         <h3 class="m-0 font-display text-2xl">Don't get deprecated</h3>
         <p class="mt-2 text-sm" style="color: rgb(var(--muted))">Open-weights LLMs that survive the deprecation calendar — Ollama, the hardware ladder, the heretic question, and the nano-gpt Saturday.</p>
       </a>
       <a href={`${base}/html-first/`} class="card hover:border-flame no-underline" style="color: rgb(var(--fg))">
-        <div class="text-xs uppercase tracking-wider mb-2" style="color: rgb(var(--accent))">Method</div>
+        <TileEyebrow added="2026-05-19" category="Method" />
         <h3 class="m-0 font-display text-2xl">HTML-ization</h3>
         <p class="mt-2 text-sm" style="color: rgb(var(--muted))">Stop sending dead files. Every report, pitch, and audit ships as a live interactive artifact — two real ones embedded and clickable.</p>
       </a>
       <a href={`${base}/launch/`} class="card hover:border-flame no-underline" style="color: rgb(var(--fg))">
-        <div class="text-xs uppercase tracking-wider mb-2" style="color: rgb(var(--accent))">The launch</div>
+        <TileEyebrow added="2026-05-20" category="The launch" />
         <h3 class="m-0 font-display text-2xl">{ed.edition} is public</h3>
         <p class="mt-2 text-sm" style="color: rgb(var(--muted))">Typewriter hero, animated stat odometer, three live embedded artifacts, all 47 chapters as a click-anywhere mosaic, a post-credit scene.</p>
       </a>
       <a href={`${base}/launch-week/`} class="card hover:border-flame no-underline" style="color: rgb(var(--fg))">
-        <div class="text-xs uppercase tracking-wider mb-2" style="color: rgb(var(--accent))">Live diary</div>
+        <TileEyebrow added="2026-05-20" category="Live diary" />
         <h3 class="m-0 font-display text-2xl">Launch week</h3>
         <p class="mt-2 text-sm" style="color: rgb(var(--muted))">The launch as its own experiment in the thesis. Four surfaces, seven days, receipts accruing — honest, even the embarrassing ones.</p>
       </a>
       <a href={`${base}/resources/`} class="card hover:border-flame no-underline" style="color: rgb(var(--fg))">
-        <div class="text-xs uppercase tracking-wider mb-2" style="color: rgb(var(--accent))">Resources</div>
+        <TileEyebrow added="2026-05-07" category="Resources" />
         <h3 class="m-0 font-display text-2xl">Vault library</h3>
         <p class="mt-2 text-sm" style="color: rgb(var(--muted))">CLAUDE.md skeletons, .mcp.json examples, hook scripts, SKILL templates, the five reusable prompts. Copy, paste, ship.</p>
       </a>
       <a href={`${base}/cheat-sheet/`} class="card hover:border-flame no-underline" style="color: rgb(var(--fg))">
-        <div class="text-xs uppercase tracking-wider mb-2" style="color: rgb(var(--accent))">Reference</div>
+        <TileEyebrow added="2026-05-07" category="Reference" />
         <h3 class="m-0 font-display text-2xl">Cheat sheet</h3>
         <p class="mt-2 text-sm" style="color: rgb(var(--muted))">Slash commands, settings, env vars, file paths, keyboard shortcuts. Print it. Tape it next to your monitor.</p>
       </a>
       <a href={`${base}/glossary/`} class="card hover:border-flame no-underline" style="color: rgb(var(--fg))">
-        <div class="text-xs uppercase tracking-wider mb-2" style="color: rgb(var(--accent))">Vocabulary</div>
+        <TileEyebrow added="2026-05-07" category="Vocabulary" />
         <h3 class="m-0 font-display text-2xl">Glossary</h3>
         <p class="mt-2 text-sm" style="color: rgb(var(--muted))">Fifty-plus terms you'll need, grouped A–Z. Linked inline throughout the book. Hover any underlined term to read it.</p>
       </a>
       <a href={`${base}/tier-list/`} class="card hover:border-flame no-underline" style="color: rgb(var(--fg))">
-        <div class="text-xs uppercase tracking-wider mb-2" style="color: rgb(var(--accent))">Tier list</div>
+        <TileEyebrow added="2026-05-07" category="Tier list" />
         <h3 class="m-0 font-display text-2xl">Rank without mercy</h3>
         <p class="mt-2 text-sm" style="color: rgb(var(--muted))">Drag-and-drop your own tier list across AI tools, connectors, and infra. The Arena leaderboard (formerly LMArena), hand-mirrored 2026-07-27, for reference — eleven boards, each with its own publish date.</p>
       </a>
       <a href={`${base}/swarms/`} class="card hover:border-flame no-underline" style="color: rgb(var(--fg))">
-        <div class="text-xs uppercase tracking-wider mb-2" style="color: rgb(var(--accent))">Orchestration</div>
+        <TileEyebrow added="2026-05-20" category="Orchestration" />
         <h3 class="m-0 font-display text-2xl">Swarms</h3>
         <p class="mt-2 text-sm" style="color: rgb(var(--muted))">Multi-agent orchestration — the four-pattern visualizer, ten swarm skills shipped, seven patterns I use, the orchestration prompts to steal. Three real multi-session screenshots.</p>
       </a>
       <a href={`${base}/github-playbook/`} class="card hover:border-flame no-underline" style="color: rgb(var(--fg))">
-        <div class="text-xs uppercase tracking-wider mb-2" style="color: rgb(var(--accent))">GitHub</div>
+        <TileEyebrow added="2026-05-20" category="GitHub" />
         <h3 class="m-0 font-display text-2xl">GitHub for non-developers</h3>
         <p class="mt-2 text-sm" style="color: rgb(var(--muted))">Five non-code uses, eight gh commands you actually need, what you can safely ignore. Six worked examples — Vlad's Playbook, AFC, Karpathy, Simon Willison ×2, profile READMEs.</p>
       </a>
       <a href={`${base}/showcase/`} class="card hover:border-flame no-underline" style="color: rgb(var(--fg))">
-        <div class="text-xs uppercase tracking-wider mb-2" style="color: rgb(var(--accent))">The stack</div>
+        <TileEyebrow added="2026-05-08" category="The stack" />
         <h3 class="m-0 font-display text-2xl">{SETUP_STATS.skills} skills · {SETUP_STATS.agents} agents · {SETUP_STATS.plugins} plugins</h3>
         <p class="mt-2 text-sm" style="color: rgb(var(--muted))">Vlad's full Claude Code setup. Every skill folder, every custom subagent, every plugin — sanitized and shareable. Freshly pruned by <span style="color: rgb(var(--accent))">the Self-Audit</span>.</p>
       </a>
       <a href={`${base}/research-notes/`} class="card hover:border-flame no-underline" style="color: rgb(var(--fg))">
-        <div class="text-xs uppercase tracking-wider mb-2" style="color: rgb(var(--accent))">Research</div>
+        <TileEyebrow added="2026-05-12" category="Research" />
         <h3 class="m-0 font-display text-2xl">What shifted this week</h3>
         <p class="mt-2 text-sm" style="color: rgb(var(--muted))">External findings that move what an operator does Monday — model releases, deprecations, benchmark shifts. Dated, sourced, signal-not-receipt discipline.</p>
       </a>

--- a/tests/eyebrow.test.mjs
+++ b/tests/eyebrow.test.mjs
@@ -1,0 +1,52 @@
+// Tests for src/lib/eyebrow.ts — the derivation behind TileEyebrow.astro.
+// The point of the feature is that "New" EXPIRES; these tests pin that rule
+// with an injected clock, which no build-day grep of dist/ can do.
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { eyebrowLabel, NEW_WINDOW_DAYS } from '../src/lib/eyebrow.ts';
+
+// Fixed clock: midnight UTC so day arithmetic below is exact.
+const NOW = Date.parse('2026-08-17T00:00:00Z');
+
+test('a page inside the window badges New and carries its ship date', () => {
+  // 29 days old — one day short of the window. If this fails, fresh pages
+  // lose their badge early and the label is lying in the other direction.
+  const { text, isNew } = eyebrowLabel('2026-07-19', 'Method', NOW);
+  assert.equal(isNew, true);
+  assert.equal(text, 'New · Jul 19 · Method');
+});
+
+test('a page at the window boundary has expired', () => {
+  // Exactly NEW_WINDOW_DAYS old — the window is exclusive. This is the
+  // half a build-day grep can never observe: flip the comparison in the
+  // lib and every tile badges forever while the build stays green.
+  const { text, isNew } = eyebrowLabel('2026-07-18', 'Method', NOW);
+  assert.equal(isNew, false);
+  assert.equal(text, 'Method');
+});
+
+test('a long-expired page renders the bare category', () => {
+  const { text, isNew } = eyebrowLabel('2026-06-10', 'Reference', NOW);
+  assert.equal(isNew, false);
+  assert.equal(text, 'Reference');
+});
+
+test('single-digit days format without padding, en-US short month, UTC', () => {
+  // Pins the "Aug 3" shape the homepage shows — a locale or timezone drift
+  // would silently reformat every badge.
+  const { text } = eyebrowLabel('2026-08-03', 'Hardware', NOW);
+  assert.equal(text, 'New · Aug 3 · Hardware');
+});
+
+test('a malformed added date throws instead of silently rendering not-new', () => {
+  // Date.parse('2026-8-17T00:00:00Z') is NaN (unpadded month misses the ISO
+  // fast path); NaN comparisons are false, so without the throw the badge
+  // would be silently absent from exactly the tile that needs it.
+  assert.throws(() => eyebrowLabel('2026-8-17', 'Method', NOW), /invalid added date/);
+});
+
+test('the window constant is the documented 30 days', () => {
+  // The tests above hardcode dates derived from 30; keep the constant and
+  // the fixtures from drifting apart silently.
+  assert.equal(NEW_WINDOW_DAYS, 30);
+});


### PR DESCRIPTION
The homepage's "New" tile labels were hand-typed and never removed — 12 of ~25 grid tiles claimed "New", including pages shipped in early June, so the badge carried no information. This replaces them with a derived, auto-expiring badge.

- New `src/components/TileEyebrow.astro`: takes `added` (the page's git ship date) + `category`; renders `New · Aug 17 · Method` in `--accent` while `added` is within 30 days of the build date, and the plain category in `--accent-2` after. The comparison runs at build time, and the hourly radar auto-update push rebuilds the site — so expiry needs no human.
- All 28 eyebrows in the main tile grid swapped to the component, with `added` backfilled from `git log --diff-filter=A` per page. The learn tile's "New here? Start here" is a different sense of new and is untouched; the "More from the shelf" grid is out of scope per the issue.
- Two label corrections that fall out of the data: the radar tile drops its stale "New ·" prefix (page shipped 2026-06-13) and keeps "Live · Updated hourly"; the opus-5 tile's hand-written "Jul 24" becomes the git-verified Jul 27.

Built today, exactly five tiles badge New: agent-workflow (Aug 17), terminal-setup (Aug 17), cad-as-code (Aug 3), music-is-math (Jul 30), opus-5 (Jul 27).

## Verification

Ran locally, in full:

- `npm run check` — 0 errors, 0 warnings (151 files)
- `npm run build` — exit 0, all prebuild guards + postbuild SEO checks pass (re-run after the review fix)
- `node --test tests/*.test.mjs` — 23/23 pass (17 SEO + 6 new eyebrow tests). The new suite was mutation-checked: flipping the expiry comparison in `src/lib/eyebrow.ts` turns 4 of the 6 red (exit 1), then restored. **Flag:** the configured spelling `node --test tests/` fails on this machine's Node v26.3.0 with `MODULE_NOT_FOUND` for the bare directory — pre-existing, unrelated to this branch, and the same Node-version trap Edition 13 documents; `.claude/workflow-kit.json`'s verification list should probably switch to the glob spelling (left out of this PR as out of scope).
- Rendered output, `grep -o 'New · [A-Z][a-z]* [0-9]*[^<]*' dist/index.html | sort`:

```
New · Aug 17 · Method
New · Aug 17 · Setup
New · Aug 3 · Hardware
New · Jul 27 · Model file
New · Jul 30 · Foundations
```

- Radar tile renders `Live · Updated hourly` with no New; `New here? Start here` appears exactly once (learn tile, unchanged); New badges render in `--accent`, expired eyebrows in `--accent-2` (verified by grep of the built div markup).
- The build's `gen-chapter-dates.py` also bumped chapter 06's modified date in `src/data/chapter-dates.json`; reverted — unrelated churn that regenerates on every build, including deploy.

## Reviewer notes

The fleet ran before this PR was opened (`review.sh plan` woke scope, simplicity and test-quality; db/security/contract not woken — nothing on the branch matches them). Every finding answered:

- **scope-reviewer — clean.** Diff sits inside the issue's entry points; every must-not-touch surface untouched; no drive-bys.
- **simplicity-reviewer — no findings.** Verified the component earns its 28 call sites, no shared date helper exists to reuse (every call site in the repo inlines `toLocaleDateString`), and no speculative props were added. Both observations were "keep as is".
- **test-quality-reviewer — three findings:**
  - *should — expiry rule untestable (Date.now() in frontmatter):* **fixed.** Derivation extracted to `src/lib/eyebrow.ts` with an injectable clock; `tests/eyebrow.test.mjs` pins the in-window badge, the exclusive 30-day boundary, the `Aug 3` formatting (en-US/UTC), and the window constant. Mutation-checked as above.
  - *nit — malformed `added` silently renders not-new (`Date.parse('2026-8-17…')` is NaN):* **fixed.** `eyebrowLabel` now throws at build time on an invalid date; covered by a test.
  - *should — nothing stops the next tile from regressing to a hand-typed `New ·`:* **deferred to #5.** A new prebuild guard script is its own concern outside this issue's entry points; filed with a prove-it-can-fail acceptance criterion.

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)
