### PR TITLE
feat: render the New tile badge as a filled accent chip

### DIFF
--- a/src/components/TileEyebrow.astro
+++ b/src/components/TileEyebrow.astro
@@ -22,12 +22,12 @@ interface Props {
   category: string;
 }
 const { added, category } = Astro.props;
-const { text, isNew, when } = eyebrowLabel(added, category);
+const { text, isNew, tail } = eyebrowLabel(added, category);
 ---
 {isNew ? (
-  <div class="tile-eyebrow--new text-xs uppercase tracking-wider mb-2" style="color: rgb(var(--accent))" aria-label={text}>
-    <span class="tile-new" aria-hidden="true">New</span>
-    <span aria-hidden="true">{when} · {category}</span>
+  <div class="tile-eyebrow--new text-xs uppercase tracking-wider mb-2" style="color: rgb(var(--accent))">
+    <span class="tile-new">New</span>
+    <span>{tail}</span>
   </div>
 ) : (
   <div class="text-xs uppercase tracking-wider mb-2" style="color: rgb(var(--accent-2))">
@@ -52,6 +52,5 @@ const { text, isNew, when } = eyebrowLabel(added, category);
     line-height: 1.4;
     padding: 0.1rem 0.5rem;
     border-radius: 999px;
-    flex: none;
   }
 </style>

--- a/src/components/TileEyebrow.astro
+++ b/src/components/TileEyebrow.astro
@@ -22,8 +22,36 @@ interface Props {
   category: string;
 }
 const { added, category } = Astro.props;
-const { text, isNew } = eyebrowLabel(added, category);
+const { text, isNew, when } = eyebrowLabel(added, category);
 ---
-<div class="text-xs uppercase tracking-wider mb-2" style={`color: rgb(var(${isNew ? '--accent' : '--accent-2'}))`}>
-  {text}
-</div>
+{isNew ? (
+  <div class="tile-eyebrow--new text-xs uppercase tracking-wider mb-2" style="color: rgb(var(--accent))" aria-label={text}>
+    <span class="tile-new" aria-hidden="true">New</span>
+    <span aria-hidden="true">{when} · {category}</span>
+  </div>
+) : (
+  <div class="text-xs uppercase tracking-wider mb-2" style="color: rgb(var(--accent-2))">
+    {text}
+  </div>
+)}
+
+<style>
+  .tile-eyebrow--new {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+  }
+  /* Filled accent chip — same white-on-accent idiom as .btn-flame and the
+     active panel pills; token-only colors so it tracks both themes. */
+  .tile-new {
+    background: rgb(var(--accent));
+    color: #fff;
+    font-weight: 700;
+    font-size: 0.62rem;
+    letter-spacing: 0.1em;
+    line-height: 1.4;
+    padding: 0.1rem 0.5rem;
+    border-radius: 999px;
+    flex: none;
+  }
+</style>

--- a/src/lib/eyebrow.ts
+++ b/src/lib/eyebrow.ts
@@ -9,7 +9,7 @@ export function eyebrowLabel(
   added: string,
   category: string,
   now: number = Date.now(),
-): { text: string; isNew: boolean } {
+): { text: string; isNew: boolean; when?: string } {
   const shipped = Date.parse(added + 'T00:00:00Z');
   if (Number.isNaN(shipped)) {
     // Fail the build, not the badge: a silent parse failure would render the
@@ -19,5 +19,7 @@ export function eyebrowLabel(
   const isNew = now - shipped < NEW_WINDOW_DAYS * 86_400_000;
   if (!isNew) return { text: category, isNew };
   const when = new Date(shipped).toLocaleDateString('en-US', { month: 'short', day: 'numeric', timeZone: 'UTC' });
-  return { text: `New · ${when} · ${category}`, isNew };
+  // `text` stays the full flat string (accessibility fallback + tests);
+  // `when` lets the component render "New" as its own chip without re-deriving.
+  return { text: `New · ${when} · ${category}`, isNew, when };
 }

--- a/src/lib/eyebrow.ts
+++ b/src/lib/eyebrow.ts
@@ -9,7 +9,7 @@ export function eyebrowLabel(
   added: string,
   category: string,
   now: number = Date.now(),
-): { text: string; isNew: boolean; when?: string } {
+): { text: string; isNew: boolean; tail?: string } {
   const shipped = Date.parse(added + 'T00:00:00Z');
   if (Number.isNaN(shipped)) {
     // Fail the build, not the badge: a silent parse failure would render the
@@ -19,7 +19,9 @@ export function eyebrowLabel(
   const isNew = now - shipped < NEW_WINDOW_DAYS * 86_400_000;
   if (!isNew) return { text: category, isNew };
   const when = new Date(shipped).toLocaleDateString('en-US', { month: 'short', day: 'numeric', timeZone: 'UTC' });
-  // `text` stays the full flat string (accessibility fallback + tests);
-  // `when` lets the component render "New" as its own chip without re-deriving.
-  return { text: `New · ${when} · ${category}`, isNew, when };
+  // `tail` is what the component renders beside the chip; `text` is composed
+  // FROM it so the flat string and the rendered badge cannot state different
+  // dates — agreement is structural, not asserted.
+  const tail = `${when} · ${category}`;
+  return { text: `New · ${tail}`, isNew, tail };
 }

--- a/tests/eyebrow.test.mjs
+++ b/tests/eyebrow.test.mjs
@@ -11,9 +11,17 @@ const NOW = Date.parse('2026-08-17T00:00:00Z');
 test('a page inside the window badges New and carries its ship date', () => {
   // 29 days old — one day short of the window. If this fails, fresh pages
   // lose their badge early and the label is lying in the other direction.
-  const { text, isNew } = eyebrowLabel('2026-07-19', 'Method', NOW);
+  const { text, isNew, when } = eyebrowLabel('2026-07-19', 'Method', NOW);
   assert.equal(isNew, true);
   assert.equal(text, 'New · Jul 19 · Method');
+  // `when` feeds the chip layout; it must agree with the flat text or the
+  // aria-label and the visible badge would state different dates.
+  assert.equal(when, 'Jul 19');
+});
+
+test('an expired page returns no `when` — the chip must not render', () => {
+  const { when } = eyebrowLabel('2026-06-10', 'Reference', NOW);
+  assert.equal(when, undefined);
 });
 
 test('a page at the window boundary has expired', () => {

--- a/tests/eyebrow.test.mjs
+++ b/tests/eyebrow.test.mjs
@@ -11,17 +11,18 @@ const NOW = Date.parse('2026-08-17T00:00:00Z');
 test('a page inside the window badges New and carries its ship date', () => {
   // 29 days old — one day short of the window. If this fails, fresh pages
   // lose their badge early and the label is lying in the other direction.
-  const { text, isNew, when } = eyebrowLabel('2026-07-19', 'Method', NOW);
+  const { text, isNew, tail } = eyebrowLabel('2026-07-19', 'Method', NOW);
   assert.equal(isNew, true);
+  // `tail` is what the badge renders beside the chip, and `text` is composed
+  // from it in the lib — both literals pinned here so a format change to
+  // either is a conscious, red-test decision.
+  assert.equal(tail, 'Jul 19 · Method');
   assert.equal(text, 'New · Jul 19 · Method');
-  // `when` feeds the chip layout; it must agree with the flat text or the
-  // aria-label and the visible badge would state different dates.
-  assert.equal(when, 'Jul 19');
 });
 
-test('an expired page returns no `when` — the chip must not render', () => {
-  const { when } = eyebrowLabel('2026-06-10', 'Reference', NOW);
-  assert.equal(when, undefined);
+test('an expired page returns no `tail` — the chip must not render', () => {
+  const { tail } = eyebrowLabel('2026-06-10', 'Reference', NOW);
+  assert.equal(tail, undefined);
 });
 
 test('a page at the window boundary has expired', () => {


### PR DESCRIPTION
The New badge from #4/#6 rendered as plain accent eyebrow text — same size and weight as every other tile label, so it didn't read as a badge. Vlad asked for it to stand out.

- **New state** now renders `NEW` as a filled accent chip (white on `rgb(var(--accent))`, bold, uppercase, 999px pill) followed by `Aug 17 · Category` in accent text. The white-on-accent treatment is the site's existing idiom (`.btn-flame`, the active panel pills) — no new color values; the token tracks both themes.
- **Expired state** untouched: plain category in `--accent-2` (byte-diff is only Astro's inert style-scoping attribute).
- **Accessibility**: the visible spans ("New" + "Aug 17 · Method") are the accessible text — no ARIA (the fleet caught that `aria-label` on a role-less div is a naming-prohibited case).
- `eyebrowLabel()` now returns `tail` ("Aug 17 · Method") and composes the flat `text` FROM it, so the rendered badge and the lib's tested string cannot state different dates by construction; existing tests untouched.

## Verification

- `node --test tests/*.test.mjs` — 28/28 pass (two new: `tail` and `text` both pinned as literals; expired returns no `tail`)
- `npm run check` — 0 errors · `npm run build` — exit 0
- `dist/index.html`: exactly **5** `tile-new` chips, on the same five tiles as before; expired eyebrows render identically; scoped CSS contains only `rgb(var(--accent))` + `#fff`

## Reviewer notes

The fleet ran before this PR was opened (scope, simplicity, test-quality woken by `review.sh plan`). Every finding answered:

- **scope-reviewer — clean.** Diff confined to the three declared entry points; judged the compiler's `data-astro-cid` byte-diff on the expired branch a non-violation (automatic artifact, zero visual/semantic change).
- **simplicity-reviewer — 1 should + 1 nit, both applied:** the three-attribute ARIA pattern (`aria-label` on a role-less div + `aria-hidden` spans) deleted — the visible spans are the accessible text; the no-op `flex: none` removed.
- **test-quality-reviewer — 2 shoulds:**
  - *text/visible-badge agreement asserted nowhere:* **fixed structurally** via the reviewer's own "cheaper still" option — `eyebrowLabel` returns the composed `tail` once and builds `text` from it, so divergence is impossible by construction; both literals pinned in tests.
  - *the isNew ternary has no repeatable post-merge observer* (a branch swap would stay green forever): **deferred in writing** — folded into #5's scope as a derived chip-count postbuild assertion (count `tile-new` in dist vs the count derived from the `added=` dates; derive, don't hardcode, so it never rots). Guard infrastructure belongs in the guard issue, not this design change.

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)
