### PR TITLE
feat: ambient glow pulse on the NEW tile chip

### DIFF
--- a/src/components/TileEyebrow.astro
+++ b/src/components/TileEyebrow.astro
@@ -53,7 +53,6 @@ const { text, isNew, tail } = eyebrowLabel(added, category);
     padding: 0.1rem 0.5rem;
     border-radius: 999px;
     position: relative;
-    isolation: isolate;
   }
   /* Ambient glow pulse. The shadow is pre-rendered on a pseudo-element and
      only its opacity animates (composited — no per-frame paint). Motion-floor
@@ -67,7 +66,6 @@ const { text, isNew, tail } = eyebrowLabel(added, category);
       border-radius: inherit;
       box-shadow: 0 0 10px 1px rgb(var(--accent) / 0.7);
       opacity: 0;
-      z-index: -1;
       animation: tile-new-glow 2.6s ease-in-out infinite;
     }
     @keyframes tile-new-glow {

--- a/src/components/TileEyebrow.astro
+++ b/src/components/TileEyebrow.astro
@@ -52,5 +52,27 @@ const { text, isNew, tail } = eyebrowLabel(added, category);
     line-height: 1.4;
     padding: 0.1rem 0.5rem;
     border-radius: 999px;
+    position: relative;
+    isolation: isolate;
+  }
+  /* Ambient glow pulse. The shadow is pre-rendered on a pseudo-element and
+     only its opacity animates (composited — no per-frame paint). Motion-floor
+     rule: everything animated lives inside no-preference; reduced-motion users
+     get the exact static chip above. */
+  @media (prefers-reduced-motion: no-preference) {
+    .tile-new::after {
+      content: '';
+      position: absolute;
+      inset: 0;
+      border-radius: inherit;
+      box-shadow: 0 0 10px 1px rgb(var(--accent) / 0.7);
+      opacity: 0;
+      z-index: -1;
+      animation: tile-new-glow 2.6s ease-in-out infinite;
+    }
+    @keyframes tile-new-glow {
+      0%, 100% { opacity: 0; }
+      50% { opacity: 0.9; }
+    }
   }
 </style>


### PR DESCRIPTION
The NEW chip gains a soft breathing glow (~2.6s cycle): the accent shadow is pre-rendered on a `::after` and only its opacity animates, so the infinite loop stays on the compositor — no per-frame paint. Everything animated lives inside `@media (prefers-reduced-motion: no-preference)`; reduced-motion users get the exact static chip from #11 (and are double-covered by the global kill-switch in global.css).

## Verification
- `npm run check` 0 errors · `npm run build` exit 0 · `node --test tests/*.test.mjs` 28/28
- Brace-matched parse of dist/index.html: the `animation:` usage and keyframes appear ONLY inside the no-preference media block; chip count still 5; glow color is `rgb(var(--accent) / 0.7)` — no new hex.

## Reviewer notes
Fleet ran pre-PR (scope, simplicity, test-quality):
- **scope — clean.** CSS-only, exactly the declared entry point.
- **simplicity — 1 should, applied:** `isolation: isolate` + `z-index: -1` were inert (an outer box-shadow can't paint over the chip's own border box and the overlay is transparent) — deleted; `position: relative` kept as the one load-bearing line. The pseudo-element/composited-opacity approach itself was judged warranted for an infinite loop.
- **test-quality — adequate, no test owed:** the chip's existence logic is already pinned in tests/eyebrow.test.mjs; the motion criteria are manual-by-design or date-dependent; a static 'all animation inside no-preference' guard would false-positive on the repo's other two legitimate motion idioms. Its one real finding is pre-existing and **filed as #13**: nothing pins the global reduced-motion kill-switch's presence in built CSS.

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)