### PR TITLE
docs: truthful README + contributor workflow docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,26 @@
 # Contributing
 
+## How work is filed and reviewed
+
+This repo runs the workflow the book's [/agent-workflow](https://dive.vladyslavpodoliako.com/agent-workflow)
+page describes — most code here is written by AI and reviewed by humans, and
+the process is built for that:
+
+- **One issue is one pull request is one concern.** File from
+  [.github/ISSUE_TEMPLATE/](.github/ISSUE_TEMPLATE/) — the bar is that an
+  agent with no memory of the conversation can read the issue and open a
+  mergeable PR. Rules live in [docs/workflow/](docs/workflow/); the config
+  every command reads is [.claude/workflow-kit.json](.claude/workflow-kit.json).
+- **Never commit to `main`.** Branch as `<type>/<issue>-<short-description>`
+  (e.g. `feat/31-leads-import`). The PR title is the squash-commit subject —
+  Conventional Commits, with `Closes #n`.
+- **The review fleet runs before the PR opens** (`.github/scripts/review.sh plan`
+  names the reviewers). No agent blocks a merge — CI is the only gate — but
+  every finding is fixed or dismissed *in writing* in the PR's Reviewer notes.
+- **State what you verified.** `npm run check` · `npm run build` (prebuild
+  guards + postbuild checks) · `node --test tests/*.test.mjs` — paste the
+  results; never claim a check passed without running it.
+
 ## Quick fixes (typos, broken links)
 
 Open a PR. Keep it tight — one typo per commit is fine. Reference the chapter

--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@
 
 ### The Ultimate AI Dive Deep
 
-**A 45-chapter operator field manual where every artifact is live, clickable, and forwardable.**
+**A 48-chapter operator field manual where every artifact is live, clickable, and forwardable — and the repo runs the discipline the book teaches.**
 
 ### → [**Read it: dive.vladyslavpodoliako.com**](https://dive.vladyslavpodoliako.com) ←
 
-[![Edition](https://img.shields.io/badge/edition-10.0-FF6B2C?style=flat-square)](https://dive.vladyslavpodoliako.com/changelog) &nbsp;
+[![Edition](https://img.shields.io/badge/edition-13-FF6B2C?style=flat-square)](https://dive.vladyslavpodoliako.com/changelog) &nbsp;
 [![Live](https://img.shields.io/badge/site-live-22D3A0?style=flat-square)](https://dive.vladyslavpodoliako.com) &nbsp;
 [![License: code MIT, content CC BY-NC-SA 4.0](https://img.shields.io/badge/license-MIT%20%2B%20CC%20BY--NC--SA-71717A?style=flat-square)](./LICENSE)
 
@@ -24,9 +24,10 @@ that started rotting the second it was exported. The link is current because
 the repo is. People forward links; they archive PDFs unread.
 
 **This repo is the proof.** The book about building this kind of artifact is,
-itself, this kind of artifact — a private GitHub repo deployed to a public
-link, updated by commit, with two real interactive case studies embedded and
-clickable inside it.
+itself, this kind of artifact — a repo deployed to a public link, updated by
+commit, with real interactive case studies embedded and clickable inside it,
+and a radar page that re-publishes itself every hour without a human in the
+loop.
 
 → Read the thesis + click the embeds: [dive.vladyslavpodoliako.com/html-first](https://dive.vladyslavpodoliako.com/html-first)
 
@@ -38,73 +39,78 @@ The repo is how it's built. The site is what it IS.
 
 | Surface | What's there | Live link |
 |---|---|---|
-| **All 45 chapters** | The whole book, MDX-rendered, with TL;DRs, glossary tooltips, code blocks, and the receipts behind every claim | [`/chapters`](https://dive.vladyslavpodoliako.com/sections) |
-| **Fable 5 — the model file** | A hub + 9 spokes on Claude Fable 5 / Mythos 5: pricing, the full benchmark table, the head-to-heads, use cases, the API, and the **system card read honestly** — ten documented pre-release behaviors, each mapped to the guardrail it demonstrates | [`/fable-5`](https://dive.vladyslavpodoliako.com/fable-5) |
-| **HTML-ization** | The flagship — thesis + 3 embedded live artifacts (AFC pitch deck, AFC robot stable, sanitized client deliverability audit) | [`/html-first`](https://dive.vladyslavpodoliako.com/html-first) |
-| **Tier list** | Every tool ranked without diplomatic phrasing, plus the live LMArena leaderboard widget | [`/tier-list`](https://dive.vladyslavpodoliako.com/tier-list) |
-| **Cheat sheet** | 16 reference sections — slash commands, settings keys, hook JSON shape, permission syntax, model routing — printable | [`/cheat-sheet`](https://dive.vladyslavpodoliako.com/cheat-sheet) |
-| **Glossary** | 67 terms, A–Z, linked inline throughout the chapters | [`/glossary`](https://dive.vladyslavpodoliako.com/glossary) |
-| **Resources** | Copy-paste templates: CLAUDE.md skeletons, .mcp.json, hooks, SKILL.md, subagent .md, Docker sandbox + devcontainer, 18 reusable prompts | [`/resources`](https://dive.vladyslavpodoliako.com/resources) |
-| **Research notes** | 11 external signals that shift what to do Monday — sourced, dated, signal-vs-receipt discipline | [`/research-notes`](https://dive.vladyslavpodoliako.com/research-notes) |
-| **The 12-rule CLAUDE.md** | Karpathy's 4 + 8 operator additions, with a receipt per rule | [`/claude-md-rules`](https://dive.vladyslavpodoliako.com/claude-md-rules) |
-| **For your CFO** | 600-word defense memo. Defend the spend. | [`/cfo-case`](https://dive.vladyslavpodoliako.com/cfo-case) |
-| **30-day plan** | Custom roadmap with markdown + .ics export | [`/thirty-day-plan`](https://dive.vladyslavpodoliako.com/thirty-day-plan) |
+| **All 48 chapters** | The whole book, MDX-rendered, with TL;DRs, glossary tooltips, and the receipts behind every claim | [`/sections`](https://dive.vladyslavpodoliako.com/sections) |
+| **Radar** | A self-updating index of what's moving through the AI ecosystem, ranked by lead time — recomputed hourly by a cron pipeline, receipts on every row | [`/radar`](https://dive.vladyslavpodoliako.com/radar) |
+| **Agent workflow** | The queue that feeds the swarm: boards, issue discipline, three slash commands, six path-routed review agents — the system this very repo runs on | [`/agent-workflow`](https://dive.vladyslavpodoliako.com/agent-workflow) |
+| **Fleet paint** | Six agents, six identical black windows — statusline, OSC escape codes, and a watcher that colors every terminal by project | [`/terminal-setup`](https://dive.vladyslavpodoliako.com/terminal-setup) |
+| **Tier list** | Five readings of the same models: the Arena crowd boards (hand-verified snapshot, cross-checked against a community mirror), Artificial Analysis with $/task economics + its Agentic Index, the labs' launch decks discounted on arrival, Arena's Agent board, and the operator ranking you can drag and share | [`/tier-list`](https://dive.vladyslavpodoliako.com/tier-list) |
+| **Model files** | Opus 5 (the effort dial, the hierarchy question) and Fable 5 / Mythos 5 (a hub + 9 spokes, the system card read honestly) | [`/opus-5`](https://dive.vladyslavpodoliako.com/opus-5) · [`/fable-5`](https://dive.vladyslavpodoliako.com/fable-5) |
+| **HTML-ization** | The flagship — thesis + embedded live artifacts (AFC pitch deck, AFC robot stable, sanitized client deliverability audit) | [`/html-first`](https://dive.vladyslavpodoliako.com/html-first) |
+| **CAD-as-code** | Claude designs a 3D-printable museum frame as 267 lines of Python — STL + STEP as build artifacts, zero grams printed until the calipers agree | [`/cad-as-code`](https://dive.vladyslavpodoliako.com/cad-as-code) |
+| **Music is math** | How AI actually writes a song, and where the same recipe conquered proteins, robots and the weather — with the five claims the first draft got wrong kept on the page | [`/music-is-math`](https://dive.vladyslavpodoliako.com/music-is-math) |
+| **Learn** | New to any of this? The official free courses in the right order, then the book | [`/learn`](https://dive.vladyslavpodoliako.com/learn) |
+| **Cheat sheet** | Slash commands, settings keys, hook JSON shape, permission syntax, model routing — printable | [`/cheat-sheet`](https://dive.vladyslavpodoliako.com/cheat-sheet) |
+| **Glossary** | 90 terms, A–Z, linked inline throughout the chapters | [`/glossary`](https://dive.vladyslavpodoliako.com/glossary) |
+| **Resources** | Copy-paste templates: CLAUDE.md skeletons, .mcp.json, hooks, SKILL.md, subagent .md, reusable prompts | [`/resources`](https://dive.vladyslavpodoliako.com/resources) |
+| **Research notes** | 13 dated external signals that shift what an operator does Monday — sourced, signal-vs-receipt discipline | [`/research-notes`](https://dive.vladyslavpodoliako.com/research-notes) |
 
 Press **⌘K** anywhere on the site — search every chapter, page, section
-anchor, glossary term, and research note from one box. A dismissible
-**"what's new" bar** at the top of every page surfaces the latest ship with its
-edition and date, driven by the changelog so it never drifts.
+anchor, glossary term, and research note from one box. The changelog drives a
+dismissible **"what's new" bar** on every page, and homepage tiles carry
+**auto-expiring NEW badges** derived from each page's git ship date — nothing
+on the site claims to be new by hand.
 
 ---
 
-## The 3 case studies, embedded and clickable
+## The repo runs the book
 
-The HTML-ization page doesn't *describe* the method — it shows it, with three
-real artifacts the operator-Claude workflow produced:
+This isn't a docs folder next to a manuscript — the repository practices the
+operating discipline the chapters describe:
 
-- **AFC — the pitch deck.** Vlad's "Autonomous Fighting Championship" — a
-  dinner-table idea ("robots in an octagon"); friends asked for a deck; one got
-  spun up fast as interactive HTML before the next meeting did. ([open it](https://dive.vladyslavpodoliako.com/artifacts/afc-pitch.html))
-- **AFC — the robot stable.** Companion doc: every humanoid platform shipping
-  in 2026, filterable, with a profit-per-fighter calculator. ([open it](https://dive.vladyslavpodoliako.com/artifacts/afc-robots.html))
-- **The 90-domain deliverability audit (sanitized sample).** A real Folderly
-  external audit of a ~90-domain / ~5K-mailbox cold-email estate — swarmed in
-  days, delivered as a clickable interactive doc instead of a 40-page PDF.
-  Client, every domain, every infra fingerprint de-identified before
-  publication. ([open it](https://dive.vladyslavpodoliako.com/artifacts/deliverability-audit-sample.html))
+- **Issues → board → branch → review fleet → PR.** Work is filed from
+  [issue templates](.github/ISSUE_TEMPLATE/) written so *an agent with no
+  memory of the conversation can open a mergeable PR*, and every branch runs a
+  path-routed review fleet before its PR opens
+  ([docs/workflow/](docs/workflow/), config in
+  [.claude/workflow-kit.json](.claude/workflow-kit.json)). The system itself is
+  documented on [`/agent-workflow`](https://dive.vladyslavpodoliako.com/agent-workflow).
+- **Prebuild guards fail the build on dishonesty**: stale numbers against a
+  ledger, broken internal links, glossary drift, nested anchors, template-literal
+  breakage — see `scripts/check-*.py` and the `prebuild` chain in `package.json`.
+- **Data pages are dated captures, not vibes.** The tier-list's Arena boards
+  are hand-verified snapshots cross-checked against an independent community
+  mirror; Artificial Analysis figures trace to the page's own embedded JSON-LD;
+  every capture is date-stamped on the surface that shows it.
+- **The radar updates itself.** A sibling pipeline pushes hourly; the site
+  rebuilds on every push (~90s via GitHub Pages), which is also what makes the
+  homepage's NEW badges expire without anyone editing a label.
 
 ---
 
 ## What's in this repo (the receipts)
 
-- **45 chapters** in `src/content/chapters/*.mdx`
-- **29 React/Astro widgets** in `src/widgets/` (live LMArena leaderboard, sortable tier list, command palette, token-burn calculator, swarm visualizer, persona-agent walkthrough, …)
-- **46 standalone pages** in `src/pages/` (the surfaces in the table above + the `/fable-5` model file & its 9 spokes, the journey, sections index, showcase, vault starter, weekend builds, and more)
-- **67 glossary terms** in `src/lib/glossary.ts`
-- **11 dated research notes** in `src/lib/research-notes.ts`
-- **3 embedded interactive artifacts** in `public/artifacts/` — single-file, self-contained, sandboxed-iframe-embedded on `/html-first`
-- **18 copy-paste prompt templates + 9 hook templates + 5 CLAUDE.md skeletons + 8 SKILL.md templates** in `src/lib/snippets.ts`
-
-The auto-updated [LMArena leaderboard widget](https://dive.vladyslavpodoliako.com/tier-list)
-pulls live from the HuggingFace datasets-server API — the rest of the site is
-static HTML.
+- **48 chapters** in `src/content/chapters/*.mdx`
+- **31 React/Astro widgets** in `src/widgets/` (Arena leaderboard, AA economics panel, sortable tier list, command palette, token-burn calculator, swarm visualizer, tokenizer lab, …)
+- **50+ standalone pages** in `src/pages/` — the surfaces above plus the journey, day zero, questions, showcase, vault starter, weekend builds, swarms, and more
+- **90 glossary terms** in `src/lib/glossary.ts` · **13 dated research notes** in `src/lib/research-notes.ts`
+- **4 embedded interactive artifacts** in `public/artifacts/` — single-file, self-contained, sandboxed-iframe-embedded
+- **35 shipped editions** in `src/lib/changelog.ts`, each with receipts
 
 ---
 
 ## How it's built (5 bullets)
 
-1. **Astro 5** static site generator (`astro build`). Server components by
-   default; React 18 islands only where interaction needs them.
+1. **Astro 5** static site generator. Server-rendered by default; React 18
+   islands only where interaction needs them.
 2. **MDX** for chapter content with custom Astro components
-   (`<Callout>`, `<PullQuote>`, `<TLDR>`, `<ScreenshotPlaceholder>`,
-   `<GlossaryTooltip>`).
+   (`<Callout>`, `<PullQuote>`, `<TLDR>`, `<GlossaryTooltip>`, …).
 3. **Tailwind 3** with project design tokens
-   (`--accent: #FF6B2C`, `--paper`, `--line`, etc.).
+   (`rgb(var(--accent))`, `--paper`, `--line`, dark/light themes).
 4. **GitHub Pages** auto-deploy via `.github/workflows/deploy.yml` — push to
    `main`, live in ~90 seconds at `dive.vladyslavpodoliako.com`.
-5. **Built by a swarm of Claude Code agents in parallel** — content migration,
-   widget builds, design system, security scrubbing, deploy pipeline. The
-   process is the technique the book describes; the artifact IS the technique.
+5. **Built and maintained by Claude Code agents** — content, widgets, data
+   refreshes, review fleets, deploys. The process is the technique the book
+   describes; the artifact IS the technique.
 
 ---
 
@@ -113,7 +119,7 @@ static HTML.
 ```bash
 npm install
 npm run dev      # http://localhost:4321
-npm run build    # static output → dist/
+npm run build    # prebuild guards → astro build → postbuild checks → dist/
 npm run preview  # serve dist/ locally
 ```
 
@@ -121,18 +127,17 @@ Requires Node 20+.
 
 ---
 
-## Add a chapter
+## Add a chapter or page
 
-1. Drop a new MDX file into `src/content/chapters/` matching the schema in
-   `src/content/config.ts`.
-2. Add the chapter to the ordered list in `src/lib/chapters.ts`.
-3. The dynamic route at `src/pages/chapters/[slug].astro` picks it up.
+1. Chapters: drop an MDX file into `src/content/chapters/` matching
+   `src/content/config.ts`, add it to `src/lib/chapters.ts` — the dynamic
+   route picks it up.
+2. Standalone pages need **eight** wiring surfaces, or they ship invisible:
+   page file · ⌘K index · chapter cross-link · glossary · homepage tile
+   (`<TileEyebrow added="…">` — the NEW badge derives from the ship date) ·
+   changelog · site nav · the hand-maintained `llms.txt` site map.
 
-To add a whole new page (resources, /tier-list-style surface, etc.), the
-six wiring surfaces are codified in the
-[`playbook-new-page`](https://github.com/Belkins/ai-dive-deep) skill: page
-file · ⌘K index · chapter cross-link · glossary term · **homepage tile** ·
-changelog.
+See [CONTRIBUTING.md](./CONTRIBUTING.md) for how work is filed and reviewed.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ The repo is how it's built. The site is what it IS.
 | **Music is math** | How AI actually writes a song, and where the same recipe conquered proteins, robots and the weather — with the five claims the first draft got wrong kept on the page | [`/music-is-math`](https://dive.vladyslavpodoliako.com/music-is-math) |
 | **Learn** | New to any of this? The official free courses in the right order, then the book | [`/learn`](https://dive.vladyslavpodoliako.com/learn) |
 | **Cheat sheet** | Slash commands, settings keys, hook JSON shape, permission syntax, model routing — printable | [`/cheat-sheet`](https://dive.vladyslavpodoliako.com/cheat-sheet) |
-| **Glossary** | 90 terms, A–Z, linked inline throughout the chapters | [`/glossary`](https://dive.vladyslavpodoliako.com/glossary) |
+| **Glossary** | 89 terms, A–Z, linked inline throughout the chapters | [`/glossary`](https://dive.vladyslavpodoliako.com/glossary) |
 | **Resources** | Copy-paste templates: CLAUDE.md skeletons, .mcp.json, hooks, SKILL.md, subagent .md, reusable prompts | [`/resources`](https://dive.vladyslavpodoliako.com/resources) |
 | **Research notes** | 13 dated external signals that shift what an operator does Monday — sourced, signal-vs-receipt discipline | [`/research-notes`](https://dive.vladyslavpodoliako.com/research-notes) |
 
@@ -92,7 +92,7 @@ operating discipline the chapters describe:
 - **48 chapters** in `src/content/chapters/*.mdx`
 - **31 React/Astro widgets** in `src/widgets/` (Arena leaderboard, AA economics panel, sortable tier list, command palette, token-burn calculator, swarm visualizer, tokenizer lab, …)
 - **50+ standalone pages** in `src/pages/` — the surfaces above plus the journey, day zero, questions, showcase, vault starter, weekend builds, swarms, and more
-- **90 glossary terms** in `src/lib/glossary.ts` · **13 dated research notes** in `src/lib/research-notes.ts`
+- **89 glossary terms** in `src/lib/glossary.ts` · **13 dated research notes** in `src/lib/research-notes.ts`
 - **4 embedded interactive artifacts** in `public/artifacts/` — single-file, self-contained, sandboxed-iframe-embedded
 - **35 shipped editions** in `src/lib/changelog.ts`, each with receipts
 


### PR DESCRIPTION
Repo housekeeping per Vlad's ask. The README had drifted badly: Edition 10.0 badge (now 13), 45 chapters (48), 29 widgets (31), 67 glossary terms (89), 11 notes (13), and one flatly false claim — 'the LMArena widget pulls live from the HuggingFace datasets-server API' (that feed 404s since the Arena rebrand; the widget is a hand-verified snapshot cross-checked against a community mirror).

- **README rewritten with only repo-derivable numbers** (48 chapters, 31 widgets, 89 glossary terms, 13 research notes, 4 artifacts, 35 editions), a current surfaces table (Radar, Agent workflow, Fleet paint, model files, CAD-as-code, Music is math, Learn…), an honest tier-list description, and a new 'The repo runs the book' section — the issue→board→fleet→PR discipline, the prebuild honesty guards, the dated-capture rules, the self-updating radar and auto-expiring NEW badges.
- **CONTRIBUTING gains 'How work is filed and reviewed'** — the workflow-kit discipline with pointers to docs/workflow, the templates and review.sh; existing sections untouched.
- **Housekeeping done directly:** deleted two fully-merged remote branches (design-system, fable-5-seo — 0 unique commits each, verified before deletion).

## Verification
- All relative links in both files resolve (checked file-by-file).
- `npm run check` clean · `node --test tests/*.test.mjs` 28/28 (docs-only change).
- Every README number spot-checked against the repo; the glossary count was corrected 90→89 after the scope review flagged a discrepancy — the built /glossary page (which prints '89 terms') is the deciding source; the reviewer's own count of 54 was also wrong.

## Reviewer notes
Fleet plan wakes only scope-reviewer for a markdown-only branch. **scope-reviewer:** boundary clean (only the two declared files); flagged the glossary number — README said 90, reviewer counted 54, ground truth is 89 (the 90 included the TS type definition; 54 missed half the record) — **fixed** to 89.

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)