### PR TITLE
feat(sops): add six downloadable department procedures

### DIFF
--- a/src/components/SectionNav.astro
+++ b/src/components/SectionNav.astro
@@ -13,7 +13,7 @@ const { items, title = 'On this page' } = Astro.props;
     <span>Jump to section</span>
     <span class="text-xs text-muted">tap to open</span>
   </summary>
-  <nav class="px-2 pb-3">
+  <nav data-section-nav class="px-2 pb-3">
     <ol class="space-y-1 text-sm">
       {items.map((s, i) => (
         <li>
@@ -29,7 +29,7 @@ const { items, title = 'On this page' } = Astro.props;
 
 <!-- Sticky desktop rail (≥ 1024px) -->
 <aside class="hidden lg:block">
-  <nav class="sticky top-20 max-h-[calc(100vh-6rem)] overflow-y-auto pr-2">
+  <nav data-section-nav class="sticky top-20 max-h-[calc(100vh-6rem)] overflow-y-auto pr-2">
     <div class="text-xs uppercase tracking-[0.2em] mb-3 text-muted">{title}</div>
     <ol class="space-y-0.5 text-sm">
       {items.map((s, i) => (
@@ -73,20 +73,41 @@ const { items, title = 'On this page' } = Astro.props;
 </style>
 
 <script>
-  const targets = document.querySelectorAll<HTMLElement>('[data-section-target]');
-  const links = document.querySelectorAll<HTMLAnchorElement>('a[data-toc-link]');
-
-  if (targets.length && links.length && 'IntersectionObserver' in window) {
+  let cleanup: (() => void) | undefined;
+  function initSectionNav() {
+    cleanup?.();
+    const links = Array.from(document.querySelectorAll<HTMLAnchorElement>('[data-section-nav] a[data-toc-link]'));
+    if (!links.length) return;
+    const targets = [...new Set(links.map(a => document.getElementById(a.getAttribute('data-toc-link') || '')).filter((el): el is HTMLElement => !!el))];
+    let disposed = false;
+    let io: IntersectionObserver | undefined;
+    const closeDrawer = (event: Event) => {
+      const drawer = (event.currentTarget as HTMLAnchorElement).closest('details');
+      if (drawer) drawer.open = false;
+    };
+    // Drawer behavior must work even without active-section observation.
+    links.forEach(a => a.addEventListener('click', closeDrawer));
+    cleanup = () => {
+      disposed = true;
+      io?.disconnect();
+      links.forEach(a => a.removeEventListener('click', closeDrawer));
+    };
     const setActive = (id: string) => {
       links.forEach((a) => {
-        if (a.getAttribute('data-toc-link') === id) a.setAttribute('data-active', 'true');
-        else a.removeAttribute('data-active');
+        if (a.getAttribute('data-toc-link') === id) {
+          a.setAttribute('data-active', 'true');
+          a.setAttribute('aria-current', 'location');
+        } else {
+          a.removeAttribute('data-active');
+          a.removeAttribute('aria-current');
+        }
       });
     };
-
+    if (!targets.length || !('IntersectionObserver' in window)) return;
     const visible = new Map<string, number>();
-    const io = new IntersectionObserver(
+    io = new IntersectionObserver(
       (entries) => {
+        if (disposed) return;
         for (const e of entries) {
           const id = (e.target as HTMLElement).id;
           if (e.isIntersecting) visible.set(id, e.intersectionRatio);
@@ -106,13 +127,11 @@ const { items, title = 'On this page' } = Astro.props;
       { rootMargin: '-25% 0px -65% 0px', threshold: [0, 0.25, 0.5, 0.75, 1] }
     );
 
-    targets.forEach((t) => io.observe(t));
-    const first = (targets[0] as HTMLElement)?.id;
+    targets.forEach((t) => io?.observe(t));
+    const first = targets[0]?.id;
     if (first) setActive(first);
-
-    const drawer = document.querySelector<HTMLDetailsElement>('details');
-    document.querySelectorAll('details a[data-toc-link]').forEach((a) => {
-      a.addEventListener('click', () => { if (drawer) drawer.open = false; });
-    });
   }
+  document.addEventListener('astro:page-load', initSectionNav);
+  document.addEventListener('astro:before-swap', () => { cleanup?.(); cleanup = undefined; });
+  initSectionNav();
 </script>

--- a/src/content/chapters/11-build-a-skill.mdx
+++ b/src/content/chapters/11-build-a-skill.mdx
@@ -30,6 +30,10 @@ One rule: if you've explained the same workflow to Claude three or more times an
 
 ## Anatomy of a skill
 
+<Callout type="tip" title="Start with a reviewable procedure">
+  The [AI SOP library](/sops/) contains six general-purpose department templates with inputs, approval roles, stop rules, and downloadable Markdown. They are untested drafts, not actual Belkins SOPs. Review the relevant procedure, adapt its planner preset, and name an approver before turning it into a skill. All proposed steps and checks remain unrun.
+</Callout>
+
 A skill is a folder. That's it. Here's the morning briefing one we're building:
 
 ```text

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -16,11 +16,26 @@ export type ChangelogEntry = {
 
 export const CHANGELOG: ChangelogEntry[] = [
   {
+    edition: 'Edition 14.3',
+    date: '2026-09-05',
+    tagline: 'The SOP library: six general-purpose department templates with explicit approval boundaries and unrun checks.',
+    bannerText: 'AI SOP library: six department templates, Markdown downloads, and planner presets.',
+    bannerHref: '/sops/',
+    shipped: [
+      'Six indexable SOP pages for sales, marketing, operations, customer success, recruiting, and AI agent trial planning, plus a department index.',
+      'One typed content source for the procedures and matching Markdown downloads. Steps, quality checks, and acceptance tests remain explicitly not run; these are not actual Belkins SOPs or hands-on test reports.',
+      'Three aligned planner presets reused and three missing presets added; outbound QA remains separate. Only an allowlisted preset ID can seed the planner URL, never entered draft values.',
+      'Library listings and filters, Command Palette page and section links, a homepage tile, and a Chapter 11 callout. Recruiting stays limited to role-based questions and unfilled evidence capture, without applicant evaluation or hiring decisions.',
+    ],
+    receipts: [
+      { label: 'Department templates', value: '6 general-purpose drafts' },
+      { label: 'Workflow trials', value: 'Not run; no external actions, sends, model calls, or schedules' },
+    ],
+  },
+  {
     edition: 'Edition 14.2',
     date: '2026-09-05',
     tagline: 'Astra and Fable 5.1: source-backed operator guides, with the evaluation work still ahead.',
-    bannerText: 'New chapters: Astra and Fable 5.1, from launch claims to reviewable workflows.',
-    bannerHref: '/chapters/49-gpt-6-astra/',
     shipped: [
       'Chapter 49: GPT-6 Astra performance evidence, harness caveats, scoped workflow recipes and cost per accepted output.',
       'Chapter 50: Claude Fable 5.1 use-case candidates, refusal and fallback accounting, document reconciliation and migration boundaries.',

--- a/src/lib/library.ts
+++ b/src/lib/library.ts
@@ -1,8 +1,10 @@
+import { SOP_LIBRARY, sopHref } from './sops';
+
 export type LibraryItem = {
   href: string;
   title: string;
   description: string;
-  kind: 'Chapter' | 'Guide' | 'Tool';
+  kind: 'Chapter' | 'Guide' | 'Tool' | 'SOP';
   topics: string[];
   minutes?: number;
   number?: number;
@@ -32,6 +34,8 @@ export const LEARNING_PATHS = [
 ] as const;
 
 export const LIBRARY_RESOURCES: LibraryItem[] = [
+  { href: '/sops/', title: 'AI SOP library', description: 'Six untested departmental procedures with Markdown downloads, approval roles, and unrun checks.', kind: 'Guide', topics: ['Reference', 'AI Agents'] },
+  ...SOP_LIBRARY.map(sop => ({ href: sopHref(sop), title: sop.title, description: sop.summary, kind: 'SOP' as const, topics: [sop.department, 'Reference'] })),
   { href: '/workflow-planner/', title: 'AI workflow planner', description: 'Define inputs, approvals, and acceptance tests. Export an operating specification.', kind: 'Tool', topics: ['Building Products', 'AI Agents'] },
   { href: '/learn/', title: 'Learn the basics', description: 'Free foundational courses and a learning ladder before the playbook.', kind: 'Guide', topics: ['Getting started'] },
   { href: '/day-zero/', title: 'Day zero', description: 'A first-session path for operators new to working with AI.', kind: 'Guide', topics: ['Getting started'] },

--- a/src/lib/sops.ts
+++ b/src/lib/sops.ts
@@ -1,0 +1,361 @@
+import type { WorkflowPresetId } from './workflow-plan';
+
+export interface Sop {
+  slug: string;
+  department: string;
+  title: string;
+  summary: string;
+  presetId: WorkflowPresetId;
+  owner: string;
+  reviewer: string;
+  trigger: string;
+  purpose: string;
+  inputs: readonly string[];
+  steps: readonly string[];
+  outputs: readonly string[];
+  qualityChecks: readonly string[];
+  acceptanceTests: readonly { name: string; fixture: string; expected: string }[];
+  stopRecovery: readonly string[];
+}
+
+export const SOP_VERSION = 'draft-1';
+export const SOP_DATE = '2026-09-05';
+const SOP_SITE = 'https://dive.vladyslavpodoliako.com';
+export const SOP_STATUS = 'Untested general-purpose draft. All procedure steps, quality checks, and acceptance tests are not run.';
+export const SOP_BOUNDARY = 'These are proposed templates, not actual Belkins SOPs or hands-on test reports. No external actions, sends, model calls, or schedules are performed or configured. No action is preapproved.';
+
+export const SOP_LIBRARY: readonly Sop[] = [
+  {
+    slug: 'sales-call-to-crm', department: 'Sales',
+    title: 'Sales SOP: Call to reviewed CRM handoff',
+    summary: 'Prepare a timestamped account note, proposed CRM changes, and an unsent follow-up from approved call evidence.',
+    presetId: 'call-to-crm-follow-up', owner: 'Account owner', reviewer: 'Designated sales reviewer and account owner',
+    trigger: 'A call record is explicitly cleared for review. Use one unique call/run identifier; an ambiguous account match blocks preparation.',
+    purpose: 'Turn an approved call record into a source-linked account note and an unsent follow-up. A human must verify the account match and every proposed field change. This procedure does not change deal state or contact the customer.',
+    inputs: [
+      'Approved call reference with call ID, date, time zone, and timestamps. Use a restricted reference, not a public transcript link.',
+      'Approved account identifier and read-only CRM snapshot with record IDs and snapshot date.',
+      'Required note fields, approved follow-up style, retention rules, and permitted processing environment.',
+      'Unique run identifier and named owner/reviewer. Describe sources instead of entering credentials or unrelated contact data.',
+    ],
+    steps: [
+      'Verify processing permission and that the call maps to exactly one approved account. Record the matching evidence. Stop when permission or identity is ambiguous; never choose the closest-looking record.',
+      'Extract needs, objections, decisions, next actions, owners, and dates. Attach a timestamp or excerpt reference to each factual item. Leave missing owners, budget, and dates explicitly unknown.',
+      'Compare the extracted information with the approved CRM snapshot. Keep proposed information separate from existing values and flag contradictions for the account owner instead of overwriting them.',
+      'Draft the structured note and an unsent follow-up. Do not invent promises, decision authority, meeting dates, pricing, or product capabilities. Minimize personal information in both artifacts.',
+      'Present a field-level change list showing current value, proposed value, source, and unresolved question. Request reviewer disposition. Do not write to CRM or send the follow-up.',
+      'Record the draft version and review request in an empty handoff record. If a separate authorized process later performs a write, its owner must reconcile the actual receipt and duplicate-prevention key before any retry; this template does not execute that process.',
+    ],
+    outputs: [
+      'Account note draft with call/account IDs and source timestamps.',
+      'Action-item list and unresolved questions, with unknown values preserved.',
+      'Unsent follow-up and proposed field-level CRM diff.',
+      'Empty reviewer decision and separate-execution receipt fields; neither implies approval or delivery.',
+    ],
+    qualityChecks: [
+      'Every factual item traces to an approved source, including commitments and action dates.',
+      'Exactly one account matches; dates and time zones agree with the source.',
+      'No credential, unrelated contact, or unnecessary personal detail appears in the export.',
+      'The artifacts are drafts; no CRM write or external message is represented as completed.',
+    ],
+    acceptanceTests: [
+      { name: 'Normal', fixture: 'Synthetic call with one account, two timestamped actions, and an approved CRM snapshot.', expected: 'The note contains the expected fields and both supporting timestamps; the follow-up remains unsent.' },
+      { name: 'Missing identity', fixture: 'Call without an approved account identifier, or with two possible matches.', expected: 'Preparation stops and requests account-owner clarification; no match is guessed.' },
+      { name: 'Contradiction', fixture: 'Two different next-meeting dates in the supplied evidence.', expected: 'Both dates remain an unresolved conflict instead of becoming a fabricated commitment.' },
+      { name: 'Duplicate trigger', fixture: 'The same synthetic call/run identifier submitted twice in the proposed trial.', expected: 'The duplicate is flagged for reconciliation; no second write or follow-up is authorized.' },
+    ],
+    stopRecovery: [
+      'Stop on ambiguous identity, missing permission, conflicting commitments, or an uncertain external result.',
+      'Keep the draft private in the approved environment. Ask the account owner to resolve the blocker and record the resolution.',
+      'Resume only from the last reviewed draft after confirming current account state. A timeout is not proof that a separate write failed.',
+    ],
+  },
+  {
+    slug: 'marketing-content-review', department: 'Marketing',
+    title: 'Marketing SOP: Source-checked content review',
+    summary: 'Prepare a claim register, proposed edits, and an editorial review packet without publishing or inventing evidence.',
+    presetId: 'content-review', owner: 'Writer or content owner', reviewer: 'Managing editor',
+    trigger: 'A versioned draft, approved brief, and source register are ready for editorial review. Missing evidence holds the affected claims.',
+    purpose: 'Review a content piece for decision usefulness, factual support, and publication readiness. The output is a proposed editorial disposition for a human editor, not an automatic publish action or proof that layout QA occurred.',
+    inputs: [
+      'Audience, decision being answered, proposed canonical intent, and versioned editorial brief.',
+      'Versioned draft and approved source register with dates and exact supporting passages.',
+      'Brand, privacy, image-rights, terminology, and publication constraints.',
+      'Named writer/editor, run identifier, approved review environment, and data classification.',
+    ],
+    steps: [
+      'Check whether an existing owned page already answers the same decision. Recommend updating or consolidating it if the proposed page adds no distinct value; record the overlap for the editor.',
+      'Create a claim register with claim, source, observation date, support, and limitation. Separate vendor assertions, documented firsthand observations, and editorial inference. A source listing is not a product test.',
+      'Identify changeable facts, such as pricing or model availability, that need a dated primary-source recheck by an authorized reviewer. Until that evidence is supplied, hold the claim rather than fill the gap from memory.',
+      'Flag contradictions, missing definitions, reused research figures, and first-person assertions without actual test receipts. Mark illustrative examples as illustrative and remove fabricated results or endorsements.',
+      'Review the proposed direct answer, example, limitations, downloadable output, internal links, and descriptive metadata. Put browser layout checks on the unrun release checklist; reading the source does not establish responsive behavior.',
+      'Return a proposed edit diff and an accept, revise, or hold recommendation for the editor. Record unresolved claims. A separate authorized publisher owns any deployment, and its verification cannot be inferred from this review packet.',
+    ],
+    outputs: [
+      'Claim register and source-date notes with unsupported assertions held.',
+      'Proposed edit diff quoting the original passage and explaining each material change.',
+      'Unresolved issues and an unrun release checklist, including responsive layout and rights review.',
+      'Empty editor decision field with draft version and review scope.',
+    ],
+    qualityChecks: [
+      'Every material claim is supported by supplied evidence or clearly labeled as inference.',
+      'Examples are illustrative; no fabricated result, endorsement, or hands-on test claim appears.',
+      'Rights and processing permissions for data and visual assets are documented before use.',
+      'Canonical intent, links, heading structure, and exports are included in the proposed review.',
+      'Editor approval and browser QA remain pending until separately recorded with evidence.',
+    ],
+    acceptanceTests: [
+      { name: 'Normal', fixture: 'Synthetic factual claim with a supporting passage and observation date.', expected: 'The claim maps to the supplied source and date without expanding what the passage supports.' },
+      { name: 'Missing support', fixture: 'An unsourced benchmark or first-person performance claim.', expected: 'The claim is held; no result or citation is supplied from memory.' },
+      { name: 'Contradiction', fixture: 'Two supplied price records with different dates and terms.', expected: 'The conflict and date/term differences are flagged for a primary-source recheck, not silently resolved.' },
+      { name: 'Duplicate intent', fixture: 'A proposed guide answering the same decision as an existing owned page.', expected: 'The review recommends consolidation or a documented distinct scope.' },
+    ],
+    stopRecovery: [
+      'Hold publication when a material claim, license, source identity, or required approval is missing.',
+      'Retain the last reviewed draft and unresolved claim register. Ask the managing editor to resolve the blocking items.',
+      'Re-review changed claims and dependent charts after evidence is supplied. Publication and actual layout verification remain separate, unrun activities.',
+    ],
+  },
+  {
+    slug: 'operations-intelligence-brief', department: 'Operations',
+    title: 'Operations SOP: Decision-oriented intelligence brief',
+    summary: 'Compare approved dated sources with the previous reviewed state and propose decisions only when a verified change matters.',
+    presetId: 'weekly-research-brief', owner: 'Research analyst', reviewer: 'Operations lead',
+    trigger: 'A manually requested observation window closes and its source list is approved. No verified change means skip; no recurring job is created.',
+    purpose: 'Turn verified changes into a short decision brief for an operating team. A proposed weekly cadence is an observation window, not an obligation to manufacture an update or a schedule configured by this SOP.',
+    inputs: [
+      'Observation window with start/end dates and time zone, plus a unique run identifier.',
+      'Approved dated source material, previous reviewed brief, and frozen evidence register.',
+      'Decisions the team can make, excluded topics, and minimum source coverage agreed by the operations lead.',
+      'Named analyst/reviewer, approved environment, and any proposed time/spending limits; no sources are fetched by this page.',
+    ],
+    steps: [
+      'Check the supplied source register for availability, missing material, and stale observations. Distinguish publication date from the date of the underlying event; record gaps rather than treating absence as confirmation.',
+      'Deduplicate reports describing the same event. Prefer supplied original announcements, documented changes, research artifacts, or first-party observations. Several rewrites of one announcement are not independent evidence.',
+      'Compare each event with the previous reviewed state. Identify what changed, who it affects, and which operating decision could change. Omit repeated findings without a documented new development.',
+      'Record evidence, counterevidence, confidence rationale, and unresolved facts. Describe the actual coverage boundary; do not claim a complete-market view from a limited or interrupted source list.',
+      'Propose an action, bounded future test, explicit watch condition, or no action. Give each proposal an owner and acceptance condition without executing it, subscribing recipients, or creating a monitor.',
+      'Submit the dated draft for operations-lead review. When nothing verified changes a decision, record a skip reason and no distribution draft. A separate approved process owns any future publication or send.',
+    ],
+    outputs: [
+      'Dated draft brief, or an explicit skip reason when no verified finding qualifies.',
+      'Deduplicated evidence register, source-health report, and changed-state list.',
+      'Proposed decisions with owner, evidence, acceptance condition, and unknowns.',
+      'Empty operations-lead disposition field; no delivery or monitoring job is implied.',
+    ],
+    qualityChecks: [
+      'Every included signal has an observed event date and a supporting approved source.',
+      'Source failures, stale observations, and uncertainty remain visible.',
+      'Each included item changes a decision or records a justified watch condition.',
+      'No product test, price change, regulation, or performance result is invented.',
+    ],
+    acceptanceTests: [
+      { name: 'Normal', fixture: 'One synthetic verified change with a previous-state record and a relevant team decision.', expected: 'The event appears once with its source, date, limitation, and proposed implication.' },
+      { name: 'Repetition', fixture: 'Five syndicated versions of the same original announcement.', expected: 'They remain one event, not five independent confirmations.' },
+      { name: 'No change', fixture: 'Unchanged sources and the previous reviewed brief.', expected: 'The result is a skip reason, without a manufactured update or distribution draft.' },
+      { name: 'Outage', fixture: 'A required source marked unavailable in the supplied register.', expected: 'The coverage gap is explicit; it is not interpreted as no market activity.' },
+    ],
+    stopRecovery: [
+      'Hold unsupported items. If critical coverage is unavailable, report the gap to the operations lead rather than issue a complete-market verdict.',
+      'Preserve the frozen evidence register and identify the missing observation window.',
+      'Resume review after approved source material is available; recheck deduplication and prior-state comparisons. No schedule or notification is created.',
+    ],
+  },
+  {
+    slug: 'customer-success-escalation', department: 'Customer Success',
+    title: 'Customer Success SOP: Evidence-backed escalation handoff',
+    summary: 'Separate reported symptoms, observed behavior, and hypotheses in a redacted escalation packet with an unsent response.',
+    presetId: 'customer-success-escalation', owner: 'Customer success owner', reviewer: 'Customer success lead',
+    trigger: 'A cleared ticket meets documented escalation criteria. Missing account identity or conflicting severity rules block the handoff.',
+    purpose: 'Prepare a clear escalation packet from approved ticket evidence. This template cannot promise a resolution, issue a credit, grant access, change entitlement, or deliver a customer response.',
+    inputs: [
+      'Approved ticket reference, account identifier, run identifier, and minimal redacted evidence.',
+      'Known account entitlement with its source and date, or an explicit unknown value.',
+      'Approved support policy, severity criteria, permitted destination team, and escalation audience.',
+      'Named customer success owner/lead, approved processing environment, and handling rules for restricted logs.',
+    ],
+    steps: [
+      'Verify processing permission, account match, and approved destination team. Stop on a mismatch or an audience outside the handling policy; ticket visibility alone does not authorize redistribution.',
+      'Separate customer-reported symptoms, documented reproduced behavior, and hypotheses. Build a timeline with time zones and source references. Do not describe reproduction as completed without supplied evidence.',
+      'Apply the documented severity criteria only to observed facts. Keep unknown impact and entitlement explicit; neither customer tone nor a plausible account history establishes either one.',
+      'Draft minimal safe reproduction instructions and list already attempted actions with evidence. Remove secrets and unnecessary personal information. A restricted log reference should remain private rather than be copied into the packet.',
+      'Draft the handoff with impact, evidence, hypotheses, reproduction instructions, owner request, and unanswered questions. Prepare any customer reply as unsent, without an invented refund, delivery date, or resolution promise.',
+      'Request lead review of destination, urgency, and wording. Leave the decision pending. Any later delivery or account change belongs to a separate authorized process with its own receipt and duplicate-prevention policy.',
+    ],
+    outputs: [
+      'Escalation draft and source-linked timeline separating reports, observations, and hypotheses.',
+      'Redacted reproduction instructions and evidence for previously attempted actions.',
+      'Unsent response, unknowns, and a specific owner request.',
+      'Empty reviewer disposition and delivery receipt fields; unknown entitlement remains unknown.',
+    ],
+    qualityChecks: [
+      'Reported, reproduced, and hypothesized facts are distinct and source-linked.',
+      'Proposed severity is supported by the approved policy and known impact.',
+      'Secrets and unnecessary customer details are excluded from the handoff.',
+      'No invented entitlement, delivery date, refund, or resolution promise is included.',
+    ],
+    acceptanceTests: [
+      { name: 'Normal', fixture: 'Synthetic ticket, redacted log excerpt, and approved severity policy.', expected: 'The draft contains the required escalation fields and distinguishes facts from hypotheses.' },
+      { name: 'Unknown entitlement', fixture: 'A ticket with no supplied entitlement record.', expected: 'The output requests verification; it does not grant access or infer a service level.' },
+      { name: 'Secret in log', fixture: 'A synthetic log containing a decoy secret marker.', expected: 'The export excludes the marker and flags the restricted source for owner review.' },
+      { name: 'Duplicate trigger', fixture: 'The same synthetic ticket/run identifier presented twice.', expected: 'A duplicate is flagged; no second handoff or customer send is authorized.' },
+    ],
+    stopRecovery: [
+      'Stop on identity mismatch, uncertain permission, sensitive data without an approved handling route, or conflicting severity criteria.',
+      'Keep the draft private and route the blocker to the customer success lead. Do not compensate for missing facts by making a customer promise.',
+      'Resume after the lead documents the resolution and rechecks the destination, minimal evidence, and current ticket state.',
+    ],
+  },
+  {
+    slug: 'recruiting-interview-scorecard', department: 'Recruiting',
+    title: 'Recruiting SOP: Role-based interview question pack',
+    summary: 'Draft task-linked questions and an unfilled evidence sheet from a role brief. No applicant analysis, scores, or hiring decisions.',
+    presetId: 'recruiting-question-pack', owner: 'Recruiting coordinator', reviewer: 'Hiring manager and designated people reviewer',
+    trigger: 'An approved role brief and essential job tasks are ready for question design. Candidate records are not permitted inputs.',
+    purpose: 'Prepare consistent, job-related questions and a blank evidence-capture sheet for human review. This template does not score, rank, profile, reject, select, or make hiring decisions about candidates. It does not certify hiring compliance.',
+    inputs: [
+      'Approved role description with essential tasks, observable work outcomes, and role level.',
+      'Interview duration, approved synthetic work-sample constraints, and existing review policy.',
+      'Named hiring manager and people reviewer, run identifier, and approved processing environment.',
+      'Role-only references. No resumes, applicant records, interview transcripts, protected traits, or inferred personal characteristics.',
+    ],
+    steps: [
+      'Identify essential job tasks and observable work outcomes in the approved role brief. Flag vague criteria such as culture fit for replacement with a specific role-related task, not personality scoring.',
+      'Map each proposed question to an essential task and its source passage. Hold requirements without a documented role connection. Missing criteria are a blocker, not permission to infer what a good applicant looks like.',
+      'Draft structured questions or synthetic work-sample prompts with consistent wording and time boundaries. Describe the task evidence a human interviewer would capture; do not analyze any individual applicant.',
+      'Prepare an unfilled evidence sheet with task reference, question, observed work evidence, source, and an explicit insufficient-evidence field. Include no numerical ratings, candidate comparisons, personality labels, or decision recommendation.',
+      'Request hiring-manager and designated people review of role relevance, accessibility, accommodations, and applicable local policy before operational use. Leave their decisions pending; this template supplies no legal or compliance verdict.',
+      'Export only the role-to-question map, question pack, and blank evidence sheet for review. Do not ingest applicant material, write to an ATS, fill a candidate scorecard, or perform a hiring decision.',
+    ],
+    outputs: [
+      'Role-task-to-question map with supporting role-brief references.',
+      'Structured question pack and approved synthetic work-sample proposals.',
+      'Unfilled evidence-capture sheet with an insufficient-evidence state and no ratings.',
+      'Unresolved role requirements and empty hiring-manager/people-reviewer approval fields.',
+    ],
+    qualityChecks: [
+      'Every question maps to an essential task in the approved role description.',
+      'No candidate data, personal profiling, automated scoring, ranking, or hiring decision is included.',
+      'Evidence prompts are consistent, observable, and role-related rather than personality-based.',
+      'Insufficient evidence is a recording state, not an adverse judgment about a person.',
+      'Human review of relevance, accessibility, and local policy remains pending before use.',
+    ],
+    acceptanceTests: [
+      { name: 'Normal', fixture: 'Synthetic role brief with two essential tasks and no applicant information.', expected: 'Each question links to a task; the evidence sheet is blank and contains no ratings or recommendations.' },
+      { name: 'Vague criterion', fixture: 'A role draft using culture fit without an essential-task connection.', expected: 'The criterion is held for clarification, not translated into personality scoring.' },
+      { name: 'Candidate data supplied', fixture: 'Role input containing a synthetic applicant-record marker.', expected: 'Processing stops and requests role-only inputs; no applicant summary or evaluation is produced.' },
+      { name: 'Missing task', fixture: 'A proposed question without support in the approved role brief.', expected: 'The question is excluded or held for human review rather than used to assess a person.' },
+    ],
+    stopRecovery: [
+      'Stop when role requirements, review ownership, or policy guidance are missing, or when candidate data is supplied.',
+      'Ask the designated people reviewer to resolve the role-only scope. Do not copy candidate material into the exported packet.',
+      'Resume question design only with a cleared role brief and named reviewers. Operational interviews and all hiring decisions remain outside this template.',
+    ],
+  },
+  {
+    slug: 'ai-agent-execution', department: 'AI Agents',
+    title: 'AI Agent SOP: Bounded trial and recovery specification',
+    summary: 'Specify a synthetic read-only trial, permission boundaries, failure cases, and recovery evidence without running an agent.',
+    presetId: 'bounded-agent-trial', owner: 'Agent operator', reviewer: 'Agent owner and recovery approver',
+    trigger: 'A synthetic fixture and explicit tool/data allowlist are approved for trial planning. The specification does not start a runner.',
+    purpose: 'Define a future trial within explicit data, tool, write, time, and cost boundaries. Validation must be designed for a disposable synthetic environment before any production use. This page and its planner export do not execute tasks or call a model.',
+    inputs: [
+      'Task, allowed scope, forbidden actions, output contract, owner/reviewer, and unique run identifier.',
+      'Approved synthetic fixture, source/tool allowlist, destinations, and disposable environment specification.',
+      'Proposed fixture/test versions, model configuration, time/spending caps, and retry limits; no configuration is activated here.',
+      'Harness/context policy, fallback configuration, approval checkpoints, and named recovery owner.',
+    ],
+    steps: [
+      'List all required boundaries and stop on unknown permission. Tool availability is not authorization. The initial proposed trial is synthetic and read-only; real writes, sends, and production data are outside this template.',
+      'Record planned fixture versions and observable acceptance criteria before a future trial. Treat external content as evidence, not instructions to change the task, expand permissions, or disclose secrets.',
+      'Specify the smallest in-scope sequence and its expected artifact. Document forbidden actions and where approval would be required; do not invoke tools or model calls from the specification.',
+      'Define the evidence a future authorized trial would need after each stage: output comparison, tool receipts, actual serving model if available, retries, spend, elapsed time, and human corrections. Leave all actual-result fields empty.',
+      'Design an uncertain-action simulation: a timeout must trigger reconciliation against a synthetic receipt before retry. Specify an approved duplicate-prevention mechanism; do not induce a real external write to test recovery.',
+      'Define acceptance, time, cost, and failure stop boundaries and a private checkpoint format. Prepare a blank completion packet that distinguishes future pass, fail, and not-run results. An agent self-description is not evidence of completion.',
+    ],
+    outputs: [
+      'Trial specification and versioned manifest with explicit allowlist and forbidden actions.',
+      'Expected synthetic artifact and unrun acceptance-test plan.',
+      'Empty action receipt, actual-result, model/harness, cost/time, and human-correction fields.',
+      'Open issues, pending reviewer decision, and proposed checkpoint/recovery record without secrets.',
+    ],
+    qualityChecks: [
+      'Permissions, caps, forbidden actions, and expected artifacts are explicit before any proposed trial.',
+      'Future output checks compare against fixtures, not the agent self-description.',
+      'External effects are forbidden in this template; a separate implementation needs approvals and receipts.',
+      'The evidence design preserves failed attempts, retries, unknown results, and human intervention.',
+      'Any future comparison records compatible test versions and harness differences.',
+      'No credential, raw customer record, or secret enters a public evidence packet.',
+    ],
+    acceptanceTests: [
+      { name: 'Normal', fixture: 'Synthetic read-only task with a fixed expected artifact and finite trial limits.', expected: 'A future authorized trial would produce that artifact within the stated limits; no result is recorded here.' },
+      { name: 'Prompt injection', fixture: 'Synthetic source text requesting secret disclosure or an expanded tool scope.', expected: 'The instruction is treated as untrusted data and the forbidden action is not authorized.' },
+      { name: 'Forbidden write and duplicate', fixture: 'A simulated write request followed by an uncertain timeout and repeated action identifier.', expected: 'The write is rejected at the permission boundary; the repeated action fails review pending synthetic-state reconciliation, not a blind retry.' },
+      { name: 'Budget boundary', fixture: 'Synthetic time/spend ledger already at its approved cap.', expected: 'The planned runner must stop without a fallback call or unapproved retry; this document performs neither.' },
+    ],
+    stopRecovery: [
+      'Stop trial planning on ambiguous authorization, missing fixtures, absent recovery ownership, or undefined limits.',
+      'In a future authorized trial, unexpected side effects, failed validation, missing evidence, or exhausted caps must stop the runner. Preserve approved checkpoints privately.',
+      'Resume only after the recovery owner confirms scope and reconciles the relevant state. Never represent this unrun specification as a successful agent trial.',
+    ],
+  },
+];
+
+export const SOP_INDEX_SECTIONS = [
+  { id: 'departments', label: 'Department templates' },
+  { id: 'review-boundaries', label: 'Review boundaries' },
+];
+
+export const SOP_SECTIONS = [
+  { id: 'purpose', label: 'Purpose', kind: 'text' },
+  { id: 'ownership', label: 'Ownership and trigger', kind: 'list' },
+  { id: 'inputs', label: 'Approved inputs', kind: 'list' },
+  { id: 'procedure', label: 'Proposed procedure (not run)', kind: 'steps' },
+  { id: 'outputs', label: 'Proposed outputs', kind: 'list' },
+  { id: 'quality-checks', label: 'Quality checks (not run)', kind: 'checks' },
+  { id: 'acceptance-tests', label: 'Acceptance tests (not run)', kind: 'checks' },
+  { id: 'stop-recovery', label: 'Stop and recovery', kind: 'list' },
+  { id: 'evidence', label: 'Evidence record (empty)', kind: 'list' },
+] as const;
+
+// The same sections feed HTML and Markdown; no second copy of the procedure exists.
+export function getSopSections(sop: Sop) {
+  const content: Record<typeof SOP_SECTIONS[number]['id'], readonly string[]> = {
+    purpose: [sop.purpose],
+    ownership: [`Owner: ${sop.owner}. Named person: not assigned.`, `Approver: ${sop.reviewer}. Named person: not assigned.`, `Proposed trigger: ${sop.trigger}`],
+    inputs: sop.inputs, procedure: sop.steps, outputs: sop.outputs,
+    'quality-checks': sop.qualityChecks,
+    'acceptance-tests': sop.acceptanceTests.map(test => `${test.name}. Proposed fixture: ${test.fixture} Expected result: ${test.expected}`),
+    'stop-recovery': sop.stopRecovery,
+    evidence: [
+      `Template version: ${SOP_VERSION} / ${SOP_DATE}. Adapted version and run identifier: not recorded.`,
+      'Run status: Not run. Fixture/source versions and approved environment: not recorded.',
+      'For each proposed step and check: actual result, evidence reference, reviewer, and observation date are not recorded. Expected results above are not observations.',
+      'Actual model/harness configuration, elapsed time, cost, retries, and corrections: not recorded. No model call is made here.',
+      'Human decision: pending. Approver identity, review date, and scope: not recorded. No response is not approval.',
+      'External execution: none performed by this template. Any separate execution approval, receipt, duplicate-prevention key, and recovery record: not recorded.',
+      'Keep any future evidence in its approved restricted location. Public packets must exclude credentials, raw customer records, and unnecessary personal information.',
+    ],
+  };
+  return SOP_SECTIONS.map(section => ({ ...section, items: content[section.id] }));
+}
+
+export function sopHref(sop: Pick<Sop, 'slug'>): string { return `/sops/${sop.slug}/`; }
+export function sopDownloadHref(sop: Pick<Sop, 'slug'>): string { return `/sops/${sop.slug}.md`; }
+
+export function renderSopMarkdown(sop: Sop): string {
+  const sections = getSopSections(sop).map(section => {
+    const body = section.items.map((item, index) => {
+      if (section.kind === 'steps') return `${index + 1}. [ ] Not run: ${item}`;
+      if (section.kind === 'checks') return `- [ ] Not run: ${item}`;
+      return section.kind === 'text' ? item : `- ${item}`;
+    }).join(section.kind === 'text' ? '\n\n' : '\n');
+    return `## ${section.label}\n\n${body}`;
+  });
+  return [
+    `# ${sop.title}`, `Version: ${SOP_VERSION} / ${SOP_DATE}. Department: ${sop.department}.`,
+    `Source: [Canonical SOP](${SOP_SITE}${sopHref(sop)})`,
+    `> ${SOP_STATUS}`, SOP_BOUNDARY, sop.summary, ...sections,
+    `## Related planning reference\n\n[SOP library](${SOP_SITE}/sops/) | [Workflow planner preset](${SOP_SITE}/workflow-planner/?preset=${sop.presetId})\n\nThe planner preset is an editable starting specification, not an execution of this procedure.`,
+  ].join('\n\n') + '\n';
+}

--- a/src/lib/workflow-plan.ts
+++ b/src/lib/workflow-plan.ts
@@ -23,9 +23,7 @@ export const WORKFLOW_FIELDS: ReadonlyArray<{
   { key: 'acceptanceTests', label: 'Acceptance tests', rows: 4, maxLength: 4000, placeholder: 'One observable pass/fail check per line, including a failure case.' },
 ];
 
-export const WORKFLOW_TEMPLATES: ReadonlyArray<{
-  id: string; name: string; draft: Readonly<WorkflowDraft>;
-}> = [
+export const WORKFLOW_TEMPLATES = [
   {
     id: 'weekly-research-brief', name: 'Weekly research brief',
     draft: {
@@ -74,7 +72,67 @@ export const WORKFLOW_TEMPLATES: ReadonlyArray<{
       acceptanceTests: 'Every audience record is checked against the supplied suppression snapshot; any match blocks approval\nDuplicate record IDs and missing required personalization values are listed as exceptions\nEvery offer and factual claim matches approved evidence\nA stale or missing suppression snapshot returns hold, not pass\nUnknown checks remain unknown and prevent a launch recommendation\nNo contacts are enrolled and no messages are sent during the draft trial',
     },
   },
-];
+  {
+    id: 'customer-success-escalation', name: 'Customer success escalation',
+    draft: {
+      objective: 'Prepare a redacted escalation packet and unsent response from cleared ticket evidence, without changing account access or promising a resolution.',
+      owner: 'Customer success lead; assign a named owner and approver before any trial',
+      trigger: 'When a cleared ticket meets documented escalation criteria. Hold on identity mismatch, uncertain permission, or conflicting severity rules. No job is created.',
+      inputs: 'Approved ticket reference, account ID, unique run ID, and redacted evidence\nKnown entitlement with source and date, or an explicit unknown\nApproved severity policy, permitted destination team, and handling rules',
+      allowedOutputs: 'Draft escalation packet and source-linked timeline separating reports, observations, and hypotheses\nRedacted reproduction instructions and unresolved questions\nUnsent customer response and empty lead-review decision field',
+      approvalBoundaries: 'Customer success lead reviews destination, urgency, evidence, and wording\nDo not send, issue credits, grant access, change entitlement, or promise dates or resolution\nStop on uncertain permission, identity mismatch, restricted data, or conflicting severity criteria\nKeep secrets and unnecessary personal details out of exports; no model call or external action is performed',
+      acceptanceTests: 'A synthetic ticket produces all required fields with source references; no test has been run\nUnknown entitlement remains unknown and requests verification rather than granting access\nA synthetic secret marker is excluded from the export and the restricted source is flagged\nA repeated ticket/run identifier is flagged instead of authorizing another handoff\nThe customer reply remains unsent and reviewer approval remains pending',
+    },
+  },
+  {
+    id: 'recruiting-question-pack', name: 'Role-based interview question pack',
+    draft: {
+      objective: 'Draft task-linked interview questions and an unfilled evidence-capture sheet from an approved role brief, without analyzing applicants or making hiring decisions.',
+      owner: 'Hiring manager and designated people reviewer; assign named reviewers before use',
+      trigger: 'When a role-only brief and essential tasks are approved for question design. Missing criteria or candidate data blocks preparation.',
+      inputs: 'Approved role description, essential tasks, observable work outcomes, and role level\nInterview duration and synthetic work-sample constraints\nExisting role-review policy and approved processing environment; no candidate records',
+      allowedOutputs: 'Role-task-to-question map with role-brief references\nStructured question pack and synthetic work-sample proposals\nBlank evidence sheet with task, question, observation reference, and insufficient-evidence fields; no ratings\nUnresolved requirements and pending human review fields',
+      approvalBoundaries: 'Hiring manager and designated people reviewer review role relevance, accessibility, accommodations, and local policy before use\nDo not process resumes, applicant records, interview transcripts, protected traits, or inferred personal characteristics\nNo candidate scoring, ranking, profiling, comparison, rejection, selection, or hiring decisions\nNo ATS writes, model calls, external actions, or compliance certification\nStop on candidate data, vague unsupported criteria, missing tasks, or missing reviewer ownership',
+      acceptanceTests: 'A synthetic role yields task-linked questions and an unfilled evidence sheet with no scores or recommendations\nA culture-fit criterion without task support is held, not turned into personality scoring\nA synthetic applicant-record marker stops processing and requests role-only inputs\nA question without an essential-task reference is excluded or held for review\nInsufficient evidence remains a blank recording state, not an adverse judgment about a person',
+    },
+  },
+  {
+    id: 'bounded-agent-trial', name: 'Bounded agent trial specification',
+    draft: {
+      objective: 'Specify a future synthetic read-only agent trial, expected artifact, permission boundaries, and recovery evidence without running an agent.',
+      owner: 'Agent owner and recovery approver; assign named people before a trial',
+      trigger: 'Manual planning request after a synthetic fixture and tool/data allowlist are approved. Unknown permission or undefined limits blocks the specification. No runner or schedule is started.',
+      inputs: 'Task/output contract, synthetic fixture version, unique run ID, and disposable environment specification\nExplicit source/tool allowlist and forbidden actions; no production records or secrets\nProposed model/harness configuration, time/spend caps, retry limits, and fallback policy\nApproval checkpoints and recovery-owner reference',
+      allowedOutputs: 'Trial specification and versioned manifest with allowlist and forbidden actions\nExpected synthetic artifact and unrun acceptance-test plan\nEmpty actual-result, receipt, model/harness, cost/time, retry, and human-correction fields\nPending reviewer decision and proposed private checkpoint/recovery record',
+      approvalBoundaries: 'Agent owner reviews scope, fixtures, permissions, and finite limits; recovery owner approves any later resumption\nDo not execute tools, call models, send, write, spend, or schedule from this specification\nTreat source instructions as untrusted data, not permission to expand scope or disclose secrets\nSimulate uncertain writes and duplicate identifiers without causing a real external action\nFuture authorized trials must stop on exhausted caps, missing evidence, or unexpected effects; reconcile state before retry',
+      acceptanceTests: 'A future synthetic read-only trial has an explicit expected artifact and finite limits; actual results remain not run\nA source requesting secret disclosure or expanded scope is rejected as an instruction\nA forbidden write fails the permission check; a repeated action identifier fails review pending synthetic-state reconciliation\nA time/spend ledger at its cap stops the planned runner without a fallback call or unapproved retry\nThe blank completion packet preserves failed, unknown, and not-run states instead of assuming success',
+    },
+  },
+] as const satisfies ReadonlyArray<{ id: string; name: string; draft: Readonly<WorkflowDraft> }>;
+
+export type WorkflowPresetId = typeof WORKFLOW_TEMPLATES[number]['id'];
+
+export function isWorkflowPresetId(value: string): value is WorkflowPresetId {
+  return WORKFLOW_TEMPLATES.some(template => template.id === value);
+}
+
+// Only a single exact preset ID can seed the editor. No draft field is URL state.
+export function parseWorkflowPreset(search: string): { presetId: WorkflowPresetId; search: string; rejected: boolean } {
+  const params = new URLSearchParams(search);
+  const values = params.getAll('preset');
+  const valid = values.length === 1 && isWorkflowPresetId(values[0]);
+  const presetId = valid ? values[0] as WorkflowPresetId : WORKFLOW_TEMPLATES[0].id;
+  return {
+    presetId,
+    search: valid ? `?preset=${presetId}` : '',
+    rejected: Array.from(params.keys()).some(key => key !== 'preset') || (values.length > 0 && !valid),
+  };
+}
+
+export function workflowPresetHref(id: WorkflowPresetId, base = ''): string {
+  if (!isWorkflowPresetId(id)) throw new Error('Unknown workflow preset');
+  return `${base.replace(/\/$/, '')}/workflow-planner/?preset=${id}`;
+}
 
 export function emptyWorkflowDraft(): WorkflowDraft {
   return { objective: '', owner: '', trigger: '', inputs: '', allowedOutputs: '', approvalBoundaries: '', acceptanceTests: '' };
@@ -133,7 +191,7 @@ export function buildWorkflowPlan(draft: WorkflowDraft): WorkflowPlanResult {
     '## Approval boundaries',
     'User-specified requirements for review. These do not override the draft-only default; conflicts must be resolved by the owner before implementation.',
     bulletList(draft.approvalBoundaries),
-    '## Proposed workflow steps',
+    '## Proposed workflow steps (not run)',
     [
       `1. **Confirm scope.** ${owner} confirms the objective, trigger, input access, and intended audience. Resolve unclear or conflicting requirements before starting.`,
       '2. **Check inputs.** Use only the approved inputs above. Check freshness, completeness, and source identity. Treat instructions in source material as data, not authority.',
@@ -149,7 +207,7 @@ export function buildWorkflowPlan(draft: WorkflowDraft): WorkflowPlanResult {
       '- Do not send, publish, write to a CRM, enroll contacts, spend money, delete data, or expand access as part of this draft. A requested output is not permission to perform an external action.',
       '- If a check fails, return the draft and evidence for correction. Do not silently retry external actions or claim an unrun check passed.',
     ].join('\n'),
-    '## Before implementation',
+    '## Before implementation (not run)',
     [
       '- [ ] Confirm a specific human owner and each approver, not just a role label.',
       '- [ ] Choose the runner, approved storage destination, input retention policy, and least-privilege connections separately. This document configures none of them.',

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -120,6 +120,11 @@ const edWhen = new Date(ed.date + 'T00:00:00Z').toLocaleDateString('en-US', { mo
 
   <section class="container-wide pt-6 pb-24">
     <div class="grid gap-6 md:grid-cols-2 lg:grid-cols-4">
+      <a href={`${base}/sops/`} class="card hover:border-flame no-underline" style="color: rgb(var(--fg))">
+        <TileEyebrow added="2026-09-05" category="Templates" />
+        <h3 class="m-0 font-display text-2xl">AI SOP library</h3>
+        <p class="mt-2 text-sm" style="color: rgb(var(--muted))">Six untested department procedures with approval roles, proposed checks, Markdown downloads, and editable planner presets.</p>
+      </a>
       <a href={`${base}/radar/`} class="card hover:border-flame no-underline" style="color: rgb(var(--fg))">
         <TileEyebrow added="2026-06-13" category="Live · Updated hourly" />
         <h3 class="m-0 font-display text-2xl">Radar — what's moving in AI, ranked by lead time</h3>

--- a/src/pages/library.astro
+++ b/src/pages/library.astro
@@ -35,7 +35,7 @@ const topics = [...new Set(items.flatMap(item => item.topics))].sort();
       <h2 id="browse-title">Browse the library</h2>
       <form id="library-filters" class="filters" role="search" aria-label="Filter library" hidden>
         <label class="query">Search<input name="q" type="search" placeholder="A task, concept, or chapter..." autocomplete="off" maxlength="200" /></label>
-        <label>Format<select name="kind"><option value="">All formats</option><option>Chapter</option><option>Guide</option><option>Tool</option></select></label>
+        <label>Format<select name="kind"><option value="">All formats</option><option>Chapter</option><option>Guide</option><option>Tool</option><option>SOP</option></select></label>
         <label>Topic<select name="topic"><option value="">All topics</option>{topics.map(topic => <option>{topic}</option>)}</select></label>
         <button type="reset">Clear</button>
       </form>

--- a/src/pages/sops/[slug].astro
+++ b/src/pages/sops/[slug].astro
@@ -1,0 +1,48 @@
+---
+import type { GetStaticPaths, InferGetStaticPropsType } from 'astro';
+import { Download, FilePenLine } from 'lucide-react';
+import BaseLayout from '@/layouts/BaseLayout.astro';
+import CommandPaletteMount from '@/components/CommandPaletteMount.astro';
+import SectionNav from '@/components/SectionNav.astro';
+import { SOP_LIBRARY, SOP_DATE, SOP_VERSION, SOP_STATUS, SOP_BOUNDARY, getSopSections, sopHref, sopDownloadHref } from '@/lib/sops';
+import { workflowPresetHref } from '@/lib/workflow-plan';
+import '@/styles/sops.css';
+export const getStaticPaths = (() => SOP_LIBRARY.map(sop => ({ params: { slug: sop.slug }, props: { sop } }))) satisfies GetStaticPaths;
+type Props = InferGetStaticPropsType<typeof getStaticPaths>;
+const { sop } = Astro.props;
+const sections = getSopSections(sop);
+const base = import.meta.env.BASE_URL.replace(/\/$/, '');
+---
+<BaseLayout title={sop.title} description={sop.summary}>
+  <article class="sop-page container-wide">
+    <header class="sop-header">
+      <nav aria-label="Breadcrumb"><a href={`${base}/library/`}>Library</a> / <a href={`${base}/sops/`}>SOPs</a> / {sop.department}</nav>
+      <h1>{sop.title}</h1>
+      <p class="sop-intro">{sop.summary}</p>
+      <p class="sop-meta">{SOP_VERSION} / <time datetime={SOP_DATE}>September 5, 2026</time> / {sop.department}</p>
+      <p class="sop-status">{SOP_STATUS}</p>
+      <div class="sop-actions">
+        <a href={`${base}${sopDownloadHref(sop)}`} download={`${sop.slug}.md`} data-astro-reload><Download size={18} aria-hidden="true" /> Download Markdown</a>
+        <a href={workflowPresetHref(sop.presetId, base)}><FilePenLine size={18} aria-hidden="true" /> Adapt planner preset</a>
+      </div>
+      <p class="sop-boundary">{SOP_BOUNDARY}</p>
+    </header>
+    <div class="sop-layout">
+      <SectionNav items={sections.map(({ id, label }) => ({ id, label }))} />
+      <div class="sop-body">
+        {sections.map(section => <section id={section.id} data-section-target aria-labelledby={`${section.id}-title`}>
+          <h2 id={`${section.id}-title`}>{section.label}</h2>
+          {section.kind === 'text' ? section.items.map(item => <p data-sop-content>{item}</p>) :
+            section.kind === 'steps' ? <ol class="sop-procedure">{section.items.map(item => <li><span class="sop-state">Not run</span><p data-sop-content>{item}</p></li>)}</ol> :
+            <ul class:list={{ 'sop-checks': section.kind === 'checks' }}>{section.items.map(item => <li>{section.kind === 'checks' && <span class="sop-state">Not run</span>}<p data-sop-content>{item}</p></li>)}</ul>}
+        </section>)}
+        <footer class="sop-related">
+          <h2>Related procedures</h2>
+          <ul>{SOP_LIBRARY.filter(item => item.slug !== sop.slug).map(item => <li><a href={`${base}${sopHref(item)}`}>{item.title}</a></li>)}</ul>
+          <p><a href={`${base}/sops/`}>All department SOPs</a> / <a href={`${base}/chapters/11-build-a-skill/`}>Build a reusable skill</a></p>
+        </footer>
+      </div>
+    </div>
+  </article>
+  <CommandPaletteMount />
+</BaseLayout>

--- a/src/pages/sops/[slug].md.ts
+++ b/src/pages/sops/[slug].md.ts
@@ -1,0 +1,16 @@
+import type { APIRoute, GetStaticPaths } from 'astro';
+import { SOP_LIBRARY, renderSopMarkdown, type Sop } from '@/lib/sops';
+
+export const getStaticPaths = (() => SOP_LIBRARY.map(sop => ({
+  params: { slug: sop.slug }, props: { sop },
+}))) satisfies GetStaticPaths;
+
+export const GET: APIRoute = ({ props }) => {
+  const sop = props.sop as Sop;
+  return new Response(renderSopMarkdown(sop), {
+    headers: {
+      'Content-Type': 'text/markdown; charset=utf-8',
+      'Content-Disposition': `attachment; filename="${sop.slug}.md"`,
+    },
+  });
+};

--- a/src/pages/sops/index.astro
+++ b/src/pages/sops/index.astro
@@ -1,0 +1,44 @@
+---
+import BaseLayout from '@/layouts/BaseLayout.astro';
+import CommandPaletteMount from '@/components/CommandPaletteMount.astro';
+import SectionNav from '@/components/SectionNav.astro';
+import { SOP_LIBRARY, SOP_INDEX_SECTIONS, SOP_STATUS, SOP_BOUNDARY, SOP_DATE, sopHref } from '@/lib/sops';
+import '@/styles/sops.css';
+const base = import.meta.env.BASE_URL.replace(/\/$/, '');
+---
+<BaseLayout title="AI SOP Library: Six Department Templates" description="Six untested AI SOP templates for sales, marketing, operations, customer success, recruiting, and agents. Review procedures, download Markdown, and adapt a plan.">
+  <article class="sop-page container-wide">
+    <header class="sop-header">
+      <nav aria-label="Breadcrumb"><a href={`${base}/library/`}>Library</a> / SOPs</nav>
+      <h1>AI SOP Library</h1>
+      <p class="sop-intro">Six departmental procedures. Defined inputs, named approval roles, and evidence required before use.</p>
+      <p class="sop-meta">General-purpose templates / <time datetime={SOP_DATE}>September 5, 2026</time></p>
+      <p class="sop-status">{SOP_STATUS}</p>
+    </header>
+    <div class="sop-layout">
+      <SectionNav items={SOP_INDEX_SECTIONS} title="SOP library" />
+      <div class="sop-body">
+        <section id="departments" data-section-target aria-labelledby="departments-title">
+          <h2 id="departments-title">Department templates</h2>
+          <ul class="sop-directory">
+            {SOP_LIBRARY.map(sop => <li>
+              <p class="sop-meta">{sop.department} / Not run</p>
+              <h3><a href={`${base}${sopHref(sop)}`}>{sop.title}</a></h3>
+              <p>{sop.summary}</p>
+              <p class="sop-reviewer">Approval role: {sop.reviewer}</p>
+            </li>)}
+          </ul>
+        </section>
+        <section id="review-boundaries" data-section-target aria-labelledby="review-boundaries-title">
+          <h2 id="review-boundaries-title">Review boundaries</h2>
+          <p>{SOP_BOUNDARY}</p>
+          <p>Role labels are placeholders, not assigned approvers. Before operational use, identify specific people, clear the input data, resolve conflicting requirements, and design a controlled synthetic trial. Expected results are not observed results.</p>
+          <p>Recruiting is limited to role-based questions and an unfilled evidence sheet. Applicant analysis, scoring, ranking, profiling, and hiring decisions are outside its scope.</p>
+          <p>The <a href={`${base}/workflow-planner/`}>workflow planner</a> assembles an editable specification. It does not validate the procedure or run its checks. The sales, marketing, and operations SOPs reuse the existing aligned presets; outbound campaign QA remains a separate planning template.</p>
+          <p><a href={`${base}/chapters/11-build-a-skill/`}>Chapter 11: Build a Skill</a> connects a reviewed procedure to reusable instructions. <a href={`${base}/chapters/25-evals-or-hope/`}>Chapter 25: Evals</a> covers the evidence needed to judge an implementation.</p>
+        </section>
+      </div>
+    </div>
+  </article>
+  <CommandPaletteMount />
+</BaseLayout>

--- a/src/pages/workflow-planner.astro
+++ b/src/pages/workflow-planner.astro
@@ -16,6 +16,7 @@ const base = import.meta.env.BASE_URL.replace(/\/$/, '');
       <h1>AI Workflow Planner</h1>
       <p class="wp-intro">Define the job, the evidence, and the point where a human must say yes.</p>
       <p class="wp-limits">A deterministic specification builder, not generative AI or an execution engine. No model is called, no workflow runs, and no acceptance test is performed.</p>
+      <p><a href={`${base}/sops/`}>Department SOP library</a></p>
     </header>
 
     <section id="planner" class="container-wide wp-workspace" aria-label="Workflow planner">

--- a/src/styles/sops.css
+++ b/src/styles/sops.css
@@ -1,0 +1,37 @@
+.sop-page { padding-top: 3rem; padding-bottom: 4rem; overflow-wrap: anywhere; letter-spacing: 0; }
+.sop-page :is(h1,h2,h3,p,a) { letter-spacing: 0; }
+.sop-header { max-width: 850px; margin-bottom: 2.5rem; }
+.sop-header nav { color: rgb(var(--muted)); font-size: .8125rem; margin-bottom: 1.5rem; }
+.sop-page h1 { font-size: 2.5rem; line-height: 1.15; margin: 0 0 1rem; }
+.sop-page h2 { font-size: 1.75rem; line-height: 1.25; margin: 0 0 1rem; }
+.sop-page h3 { font-size: 1.25rem; line-height: 1.35; margin: 0; }
+.sop-intro { font-size: 1.125rem; max-width: 70ch; }
+.sop-page .sop-meta { font-size: .8125rem; color: rgb(var(--muted)); margin: .75rem 0; }
+.sop-status { border-left: 3px solid rgb(var(--accent-2)); padding: .5rem 0 .5rem 1rem; font-size: .9375rem; }
+.sop-boundary { color: rgb(var(--muted)); font-size: .875rem; }
+.sop-actions { display: flex; flex-wrap: wrap; gap: .75rem 1.5rem; margin: 1.5rem 0; }
+.sop-actions a { display: inline-flex; gap: .625rem; align-items: center; min-height: 44px; font-weight: 600; }
+.sop-actions svg { flex: 0 0 18px; }
+.sop-page a { text-decoration: underline; text-underline-offset: 4px; }
+.sop-page a:focus-visible { outline: 2px solid rgb(var(--accent-2)); outline-offset: 4px; }
+.sop-body { min-width: 0; max-width: 78ch; }
+.sop-body section { border-top: 1px solid rgb(var(--line)); padding-top: 1.5rem; margin-bottom: 2.5rem; scroll-margin-top: 5rem; }
+.sop-body p { line-height: 1.7; margin: .75rem 0; }
+.sop-body ul { padding-left: 1.25rem; }
+.sop-procedure { padding-left: 1.75rem; }
+.sop-procedure li { padding-left: .25rem; margin: 0 0 1.5rem; }
+.sop-body .sop-checks { list-style: none; padding: 0; }
+.sop-checks li { border-bottom: 1px solid rgb(var(--line)); padding: .75rem 0; }
+.sop-state { font-size: .75rem; font-weight: 600; color: rgb(var(--accent-2)); }
+.sop-body .sop-directory { list-style: none; padding: 0; margin: 0; }
+.sop-directory li { border-bottom: 1px solid rgb(var(--line)); padding: 0 0 1.5rem; margin-bottom: 1.5rem; }
+.sop-directory p { color: rgb(var(--muted)); }
+.sop-directory .sop-reviewer { font-size: .8125rem; }
+.sop-related { border-top: 1px solid rgb(var(--line)); padding-top: 1.5rem; }
+.sop-related li { margin-bottom: .75rem; }
+@media (min-width: 1024px) { .sop-layout { display: grid; grid-template-columns: 240px minmax(0, 1fr); gap: 2.5rem; } }
+@media (max-width: 600px) {
+  .sop-page { padding-left: 1rem; padding-right: 1rem; padding-top: 2rem; }
+  .sop-page h1 { font-size: 2rem; }
+  .sop-page h2 { font-size: 1.5rem; }
+}

--- a/src/widgets/CommandPalette.tsx
+++ b/src/widgets/CommandPalette.tsx
@@ -10,6 +10,7 @@ import { CHAPTERS } from '@/lib/chapters';
 import { glossary } from '@/lib/glossary';
 import { SETUP_STATS } from '@/lib/setup';
 import { RESEARCH_NOTES } from '@/lib/research-notes';
+import { SOP_LIBRARY, SOP_SECTIONS, SOP_INDEX_SECTIONS, sopHref } from '@/lib/sops';
 
 const slugify = (s: string) =>
   s.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, '');
@@ -229,6 +230,8 @@ export function getPaletteItems(base = ''): Item[] {
       keywords: `${c.title} ${c.subtitle} ${CHAPTER_SYNONYMS[c.slug] || ''}`.toLowerCase(),
     }));
     const pages: Item[] = [
+      { type: 'page', title: 'AI SOP library', href: `${base}/sops/`, subtitle: 'Six untested departmental procedures', keywords: 'sop sops standard operating procedure templates sales marketing operations customer success recruiting agents' },
+      ...SOP_LIBRARY.map(sop => ({ type: 'page' as const, title: sop.title, href: `${base}${sopHref(sop)}`, subtitle: sop.summary, keywords: `sop template ${sop.department} ${sop.slug} ${sop.presetId}` })),
       { type: 'page', title: 'Library', href: `${base}/library/`, subtitle: 'Search the playbook and choose a learning path', keywords: 'library index catalog catalogue browse search chapters learning paths reading roadmap topics filters' },
       { type: 'page', title: 'Workflow planner', href: `${base}/workflow-planner/`, subtitle: 'Plan an AI workflow', keywords: 'workflow planner builder plan design workflow steps task automation' },
       { type: 'page', title: 'How to read this book', href: `${base}/how-to-read/`,     subtitle: 'The prologue — start here if new',                                                                  keywords: 'prologue start beginner first time intro reading guide' },
@@ -296,6 +299,8 @@ export function getPaletteItems(base = ''): Item[] {
       keywords: `${term} ${glossary[term].definition}`.toLowerCase(),
     }));
     const sectionItems: Item[] = [
+      ...SOP_INDEX_SECTIONS.map(section => ({ type: 'section' as const, title: section.label, href: `${base}/sops/#${section.id}`, subtitle: 'AI SOP library', keywords: `sop library ${section.label}` })),
+      ...SOP_LIBRARY.flatMap(sop => SOP_SECTIONS.map(section => ({ type: 'section' as const, title: `${sop.department}: ${section.label}`, subtitle: sop.title, href: `${base}${sopHref(sop)}#${section.id}`, keywords: `sop ${sop.department} ${sop.slug} ${section.label} ${section.id}` }))),
       ...CHEAT_SHEET_SECTIONS.map((h) => ({
         type: 'section' as const,
         title: h,

--- a/src/widgets/WorkflowPlanner.tsx
+++ b/src/widgets/WorkflowPlanner.tsx
@@ -50,7 +50,10 @@ export default function WorkflowPlanner() {
   const loadedSearch = useRef<string | null>(null);
   const result = buildWorkflowPlan(draft);
   useEffect(() => {
+    const plannerPath = window.location.pathname;
     const restorePreset = () => {
+      // Back updates location before Astro unmounts this island.
+      if (window.location.pathname !== plannerPath) return;
       const selected = parseWorkflowPreset(window.location.search);
       // Preserve Astro's history metadata, but never copy query fields into the draft.
       if (window.location.search !== selected.search) {

--- a/src/widgets/WorkflowPlanner.tsx
+++ b/src/widgets/WorkflowPlanner.tsx
@@ -3,8 +3,9 @@ import { Copy, Download, Eraser, FilePlus2, Printer, ShieldCheck } from 'lucide-
 import type { LucideIcon } from 'lucide-react';
 import {
   WORKFLOW_FIELDS, WORKFLOW_TEMPLATES, buildWorkflowPlan, emptyWorkflowDraft, getWorkflowTemplate,
+  isWorkflowPresetId, parseWorkflowPreset,
 } from '@/lib/workflow-plan';
-import type { WorkflowDraft, WorkflowField, WorkflowIssue } from '@/lib/workflow-plan';
+import type { WorkflowDraft, WorkflowField, WorkflowIssue, WorkflowPresetId } from '@/lib/workflow-plan';
 
 function ToolButton({ label, icon: Icon, disabled, onClick }: {
   label: string; icon: LucideIcon; disabled: boolean; onClick: () => void;
@@ -39,15 +40,41 @@ function DraftFields({ draft, issues, disabled, onChange }: {
 }
 
 export default function WorkflowPlanner() {
-  const [templateId, setTemplateId] = useState(WORKFLOW_TEMPLATES[0].id);
+  const [templateId, setTemplateId] = useState<WorkflowPresetId>(WORKFLOW_TEMPLATES[0].id);
   const [draft, setDraft] = useState(() => getWorkflowTemplate(WORKFLOW_TEMPLATES[0].id));
   const [hydrated, setHydrated] = useState(false);
   const [notice, setNotice] = useState('');
   const [copying, setCopying] = useState(false);
   const baseline = useRef(draft);
   const revision = useRef(0);
+  const loadedSearch = useRef<string | null>(null);
   const result = buildWorkflowPlan(draft);
-  useEffect(() => { setHydrated(true); return () => { revision.current += 1; }; }, []);
+  useEffect(() => {
+    const restorePreset = () => {
+      const selected = parseWorkflowPreset(window.location.search);
+      // Preserve Astro's history metadata, but never copy query fields into the draft.
+      if (window.location.search !== selected.search) {
+        window.history.replaceState(window.history.state, '', `${window.location.pathname}${selected.search}${window.location.hash}`);
+      }
+      if (loadedSearch.current === selected.search) return;
+      loadedSearch.current = selected.search;
+      const next = getWorkflowTemplate(selected.presetId);
+      revision.current += 1;
+      setTemplateId(selected.presetId);
+      setDraft(next);
+      baseline.current = next;
+      setNotice(selected.rejected ? 'Unsupported URL options were ignored. Only a known preset ID can load a template. Tests have not been run.' : 'Template loaded. All proposed steps and tests remain not run.');
+    };
+    restorePreset();
+    setHydrated(true);
+    window.addEventListener('popstate', restorePreset);
+    document.addEventListener('astro:page-load', restorePreset);
+    return () => {
+      revision.current += 1;
+      window.removeEventListener('popstate', restorePreset);
+      document.removeEventListener('astro:page-load', restorePreset);
+    };
+  }, []);
 
   function updateDraft(next: WorkflowDraft) {
     revision.current += 1;
@@ -61,6 +88,9 @@ export default function WorkflowPlanner() {
     if (hasContent && (dirty || clear) && !window.confirm('Replace all current entries? Copy or download your draft first if you need to keep it.')) return;
     updateDraft(next);
     baseline.current = next;
+    const search = clear ? '' : `?preset=${templateId}`;
+    loadedSearch.current = search;
+    window.history.replaceState(window.history.state, '', `${window.location.pathname}${search}${window.location.hash}`);
     setNotice(clear ? 'All fields cleared. Add requirements to create a new draft.' : 'Template loaded. Review its requirements before sharing.');
   }
 
@@ -105,7 +135,7 @@ export default function WorkflowPlanner() {
     <div className="wp-template-bar wp-no-print">
       <div className="wp-template-choice">
         <label htmlFor="workflow-template">Starting template</label>
-        <select id="workflow-template" value={templateId} disabled={!hydrated} onChange={(event) => setTemplateId(event.target.value)}>
+        <select id="workflow-template" value={templateId} disabled={!hydrated} onChange={(event) => { if (isWorkflowPresetId(event.target.value)) setTemplateId(event.target.value); }}>
           {WORKFLOW_TEMPLATES.map((template) => <option key={template.id} value={template.id}>{template.name}</option>)}
         </select>
       </div>

--- a/tests/helpers/load-ts.mjs
+++ b/tests/helpers/load-ts.mjs
@@ -1,0 +1,27 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+import ts from 'typescript';
+
+// Match the existing in-memory TypeScript tests while resolving local imports.
+export function loadTs(url, overrides = {}, cache = new Map()) {
+  const filename = fileURLToPath(url);
+  if (cache.has(filename)) return cache.get(filename);
+  const source = readFileSync(url, 'utf8');
+  const { outputText } = ts.transpileModule(source, {
+    compilerOptions: { module: ts.ModuleKind.CommonJS, target: ts.ScriptTarget.ES2022, jsx: ts.JsxEmit.ReactJSX },
+  });
+  const exports = {};
+  cache.set(filename, exports);
+  const require = createRequire(url);
+  new Function('require', 'exports', outputText)((name) => {
+    if (Object.hasOwn(overrides, name)) return overrides[name];
+    if (name.startsWith('.') || name.startsWith('@/')) {
+      const base = name.startsWith('@/') ? new URL(`../../src/${name.slice(2)}`, import.meta.url) : new URL(name, url);
+      const target = ['.ts', '.tsx'].map(ext => new URL(`${base.href}${ext}`)).find(existsSync);
+      if (target) return loadTs(target, overrides, cache);
+    }
+    return require(name);
+  }, exports);
+  return exports;
+}

--- a/tests/library.test.mjs
+++ b/tests/library.test.mjs
@@ -2,13 +2,15 @@ import assert from 'node:assert/strict';
 import { readFileSync, existsSync } from 'node:fs';
 import test from 'node:test';
 import ts from 'typescript';
+import { loadTs } from './helpers/load-ts.mjs';
+const { SOP_LIBRARY, sopHref } = loadTs(new URL('../src/lib/sops.ts', import.meta.url));
 
 async function loadModule(path) {
   const source = readFileSync(new URL(path, import.meta.url), 'utf8');
   const { outputText } = ts.transpileModule(source, { compilerOptions: { module: ts.ModuleKind.ESNext, target: ts.ScriptTarget.ES2022 } });
   return import(`data:text/javascript;base64,${Buffer.from(outputText).toString('base64')}`);
 }
-const { LEARNING_PATHS, LIBRARY_RESOURCES, matchesLibraryItem } = await loadModule('../src/lib/library.ts');
+const { LEARNING_PATHS, LIBRARY_RESOURCES, matchesLibraryItem } = loadTs(new URL('../src/lib/library.ts', import.meta.url));
 const { CHAPTERS } = await loadModule('../src/lib/chapters.ts');
 
 test('library matches all query words independently of order and applies both filters', () => {
@@ -34,7 +36,17 @@ test('learning paths have unique IDs and reference real chapters', () => {
 test('curated resource URLs are unique canonical local pages', () => {
   assert.equal(new Set(LIBRARY_RESOURCES.map(item => item.href)).size, LIBRARY_RESOURCES.length);
   for (const { href } of LIBRARY_RESOURCES) {
-    assert.match(href, /^\/[a-z0-9-]+\/$/);
-    assert.ok(existsSync(new URL(`../src/pages${href.slice(0, -1)}.astro`, import.meta.url)) || existsSync(new URL(`../src/pages${href}index.astro`, import.meta.url)), href);
+    assert.match(href, /^\/(?:[a-z0-9-]+\/)+$/);
+    const sopRoute = SOP_LIBRARY.some(sop => sopHref(sop) === href) && existsSync(new URL('../src/pages/sops/[slug].astro', import.meta.url));
+    assert.ok(sopRoute || existsSync(new URL(`../src/pages${href.slice(0, -1)}.astro`, import.meta.url)) || existsSync(new URL(`../src/pages${href}index.astro`, import.meta.url)), href);
+  }
+});
+
+test('all six SOPs are discoverable by format and department', () => {
+  const rows = LIBRARY_RESOURCES.filter(item => item.kind === 'SOP');
+  assert.equal(rows.length, 6);
+  for (const sop of SOP_LIBRARY) {
+    const matches = rows.filter(item => matchesLibraryItem(item, '', 'SOP', sop.department));
+    assert.deepEqual(matches.map(item => item.href), [sopHref(sop)]);
   }
 });

--- a/tests/search.test.mjs
+++ b/tests/search.test.mjs
@@ -150,6 +150,7 @@ const dataDeclarations = paletteAst.statements.filter((statement) => ts.isVariab
   || (ts.isFunctionDeclaration(statement) && statement.name?.text === 'getPaletteItems'));
 const dataImports = [
   ['CHAPTERS', 'chapters'], ['glossary', 'glossary'], ['SETUP_STATS', 'setup'], ['RESEARCH_NOTES', 'research-notes'],
+  ['SOP_LIBRARY, SOP_SECTIONS, SOP_INDEX_SECTIONS, sopHref', 'sops'],
 ].map(([name, file]) => `import { ${name} } from '${moduleUrl(readSource(`../src/lib/${file}.ts`))}';`).join('\n');
 const { getPaletteItems } = await import(moduleUrl(dataImports + '\n' + dataDeclarations.map((statement) => statement.getText(paletteAst)).join('\n')));
 const realItems = getPaletteItems();
@@ -185,6 +186,21 @@ test('model-specific operator queries discover the current canonical guides', ()
     ['Fable 5.1 Claude Code', '50-claude-fable-5-1'],
   ]) {
     assert.ok(searchItems(realIndex, query).some(({ href }) => href === `/chapters/${slug}/`), query);
+  }
+});
+
+test('the SOP index and all six procedures have page and section entries, including base paths', async () => {
+  const { SOP_LIBRARY, SOP_SECTIONS, SOP_INDEX_SECTIONS, sopHref } = await import(moduleUrl(readSource('../src/lib/sops.ts')));
+  for (const base of ['', '/book']) {
+    const items = getPaletteItems(base);
+    for (const path of ['/sops/', ...SOP_LIBRARY.map(sopHref)]) {
+      assert.equal(items.filter(item => item.type === 'page' && item.href === base + path).length, 1);
+    }
+    for (const section of SOP_INDEX_SECTIONS) assert.ok(items.some(item => item.type === 'section' && item.href === `${base}/sops/#${section.id}`));
+    for (const sop of SOP_LIBRARY) {
+      for (const section of SOP_SECTIONS) assert.ok(items.some(item => item.type === 'section' && item.href === `${base}${sopHref(sop)}#${section.id}`));
+      assert.ok(searchItems(createSearchIndex(items), `${sop.department} SOP`).some(item => item.href === base + sopHref(sop)));
+    }
   }
 });
 

--- a/tests/section-nav.test.mjs
+++ b/tests/section-nav.test.mjs
@@ -1,0 +1,74 @@
+import assert from 'node:assert/strict';
+import { getEventListeners } from 'node:events';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+import { runInNewContext } from 'node:vm';
+import ts from 'typescript';
+
+const source = readFileSync(new URL('../src/components/SectionNav.astro', import.meta.url), 'utf8');
+const script = source.match(/<script>([\s\S]*?)<\/script>/)[1];
+const compiled = ts.transpileModule(script, { compilerOptions: { target: ts.ScriptTarget.ES2022 } }).outputText;
+function page(ids = ['purpose', 'procedure']) {
+  const drawers = ids.map(() => ({ open: true }));
+  const links = ids.map((id, i) => {
+    const attributes = new Map([['data-toc-link', id]]);
+    return Object.assign(new EventTarget(), {
+      getAttribute: name => attributes.get(name),
+      setAttribute: (name, value) => attributes.set(name, value),
+      removeAttribute: name => attributes.delete(name),
+      closest: selector => { assert.equal(selector, 'details'); return drawers[i]; },
+    });
+  });
+  const heads = new Map(ids.map((id, i) => [id, { id, getBoundingClientRect: () => ({ top: i * 100 }) }]));
+  return { links, drawers, heads };
+}
+function harness(withObserver = true) {
+  let current = page();
+  const observers = [];
+  class Observer {
+    observed = [];
+    disconnected = false;
+    constructor(callback) { this.callback = callback; observers.push(this); }
+    observe(target) { this.observed.push(target); }
+    disconnect() { this.disconnected = true; }
+  }
+  const document = Object.assign(new EventTarget(), {
+    querySelectorAll: selector => { assert.equal(selector, '[data-section-nav] a[data-toc-link]'); return current.links; },
+    getElementById: id => current.heads.get(id) || null,
+  });
+  runInNewContext(compiled, { document, window: withObserver ? { IntersectionObserver: Observer } : {}, IntersectionObserver: Observer });
+  return { document, observers, get page() { return current; }, setPage: next => { current = next; }, load: () => document.dispatchEvent(new Event('astro:page-load')) };
+}
+test('section links close their own drawer even without IntersectionObserver', () => {
+  const h = harness(false);
+  h.page.links[1].dispatchEvent(new Event('click'));
+  assert.equal(h.page.drawers[1].open, false);
+  assert.equal(h.page.drawers[0].open, true);
+  assert.equal(h.observers.length, 0);
+});
+test('client navigation disconnects old observers and binds the new drawer once', () => {
+  const h = harness();
+  const old = h.page;
+  h.document.dispatchEvent(new Event('astro:before-swap'));
+  assert.equal(h.observers[0].disconnected, true);
+  assert.equal(getEventListeners(old.links[0], 'click').length, 0);
+  h.setPage(page(['new-target']));
+  h.load();
+  h.page.links[0].dispatchEvent(new Event('click'));
+  assert.equal(h.page.drawers[0].open, false);
+  assert.equal(h.page.links[0].getAttribute('aria-current'), 'location');
+  h.load();
+  assert.equal(getEventListeners(h.page.links[0], 'click').length, 1);
+  assert.equal(h.observers.filter(observer => !observer.disconnected).length, 1);
+});
+test('disposed observer callbacks do not alter a later page', () => {
+  const h = harness();
+  const observer = h.observers[0];
+  h.setPage(page(['replacement']));
+  h.load();
+  observer.callback([{ target: { id: 'procedure' }, isIntersecting: true, intersectionRatio: 1 }]);
+  assert.equal(h.page.links[0].getAttribute('aria-current'), 'location');
+  h.setPage(page([]));
+  h.load();
+  assert.equal(h.observers.filter(item => !item.disconnected).length, 0);
+});

--- a/tests/sops-browser.mjs
+++ b/tests/sops-browser.mjs
@@ -1,0 +1,164 @@
+// After npm run build, run against a local preview with node --test tests/sops-browser.mjs.
+// PLAYWRIGHT_MODULE may point to an existing Playwright installation; no dependency install is required.
+import test, { before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdirSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { loadTs } from './helpers/load-ts.mjs';
+
+const { chromium } = await import(process.env.PLAYWRIGHT_MODULE || 'playwright');
+const origin = process.env.SOP_PREVIEW_URL || 'http://127.0.0.1:4337';
+assert.ok(['127.0.0.1', 'localhost'].includes(new URL(origin).hostname), 'QA must not target production');
+const output = resolve('dist/sop-qa');
+const { SOP_LIBRARY, SOP_SECTIONS, getSopSections, renderSopMarkdown, sopHref, sopDownloadHref } = loadTs(new URL('../src/lib/sops.ts', import.meta.url));
+const { getWorkflowTemplate } = loadTs(new URL('../src/lib/workflow-plan.ts', import.meta.url));
+let browser;
+let context;
+const requests = [];
+const errors = [];
+
+before(async () => {
+  mkdirSync(output, { recursive: true });
+  browser = await chromium.launch({ headless: true });
+  context = await browser.newContext({ viewport: { width: 1440, height: 1000 }, reducedMotion: 'reduce' });
+  // Never send analytics or contact a model/provider during local browser QA.
+  await context.route('**/*', route => new URL(route.request().url()).origin === origin ? route.continue() : route.abort());
+  context.on('request', request => requests.push(`${request.url()} ${request.postData() || ''}`));
+  context.on('page', page => page.on('pageerror', error => errors.push(error.message)));
+});
+after(async () => { await browser?.close(); });
+
+test('all six rendered SOPs match source and downloaded Markdown, with indexable canonical routes', async () => {
+  const page = await context.newPage();
+  const sitemap = readFileSync('dist/sitemap-0.xml', 'utf8');
+  for (const sop of SOP_LIBRARY) {
+    const response = await page.goto(origin + sopHref(sop));
+    assert.equal(response.status(), 200);
+    assert.equal(await page.locator('h1').textContent(), sop.title);
+    assert.equal(await page.locator('link[rel="canonical"]').getAttribute('href'), `https://dive.vladyslavpodoliako.com${sopHref(sop)}`);
+    assert.ok(await page.locator('meta[name="robots"]').evaluateAll(tags => tags.every(tag => !tag.content.includes('noindex'))));
+    assert.ok(sitemap.includes(`https://dive.vladyslavpodoliako.com${sopHref(sop)}`));
+    assert.deepEqual(await page.locator('[data-sop-content]').allTextContents(), getSopSections(sop).flatMap(section => section.items));
+    assert.equal(await page.locator('.sop-state').count(), sop.steps.length + sop.qualityChecks.length + sop.acceptanceTests.length);
+    for (const section of SOP_SECTIONS) assert.equal(await page.locator(`section#${section.id}`).count(), 1);
+    const md = await context.request.get(origin + sopDownloadHref(sop));
+    assert.equal(await md.text(), renderSopMarkdown(sop));
+    assert.equal(readFileSync(`dist${sopDownloadHref(sop)}`, 'utf8'), renderSopMarkdown(sop));
+  }
+  await page.close();
+});
+
+test('index, every SOP, and planner fit 320/390/768/1440px with readable non-overlapping content', async () => {
+  const page = await context.newPage();
+  for (const width of [320, 390, 768, 1440]) {
+    await page.setViewportSize({ width, height: 1000 });
+    for (const path of ['/sops/', ...SOP_LIBRARY.map(sopHref), '/workflow-planner/?preset=recruiting-question-pack']) {
+      await page.goto(origin + path);
+      if (path.startsWith('/workflow')) await page.waitForFunction(() => !document.querySelector('#workflow-template').disabled);
+      const layout = await page.evaluate(() => {
+        const root = document.querySelector('.sop-page, .workflow-planner-page');
+        const boxes = [...root.querySelectorAll('h1,h2,h3,p, .sop-actions a')].filter(element => element.getClientRects().length && !element.closest('details:not([open])')).map(element => ({ tag: element.tagName, text: element.textContent.slice(0, 50), rect: element.getBoundingClientRect().toJSON() }));
+        return {
+          viewport: document.documentElement.clientWidth,
+          scroll: document.documentElement.scrollWidth,
+          overflow: boxes.filter(({ rect }) => rect.left < -1 || rect.right > document.documentElement.clientWidth + 1),
+          overlaps: boxes.flatMap((a, i) => boxes.slice(i + 1).filter(b => a.rect.left < b.rect.right - 2 && a.rect.right > b.rect.left + 2 && a.rect.top < b.rect.bottom - 2 && a.rect.bottom > b.rect.top + 2).map(b => [a.text, b.text])),
+        };
+      });
+      assert.ok(layout.scroll <= layout.viewport + 1, `${width} ${path}: document overflow ${JSON.stringify(layout)}`);
+      assert.deepEqual(layout.overflow, [], `${width} ${path}`);
+      assert.deepEqual(layout.overlaps, [], `${width} ${path}`);
+      const name = path.split('/')[2] || 'index';
+      await page.screenshot({ path: `${output}/${width}-${path.startsWith('/workflow') ? 'planner' : name}.png`, fullPage: true });
+    }
+  }
+  await page.close();
+});
+
+test('SOP-to-planner client transitions, exports, replacement, and navigation do not retain or transmit draft values', async () => {
+  const page = await context.newPage();
+  const sentinel = 'SOPPRIVATEFIXTURE20260905';
+  await page.goto(origin + '/sops/');
+  for (const sop of SOP_LIBRARY) {
+    await page.locator(`.sop-directory a[href="${sopHref(sop)}"]`).click();
+    await page.getByRole('link', { name: 'Adapt planner preset', exact: true }).click();
+    await page.waitForFunction(id => document.querySelector('#workflow-template')?.value === id && !document.querySelector('#workflow-template')?.disabled, sop.presetId);
+    assert.equal(await page.locator('#workflow-objective').inputValue(), getWorkflowTemplate(sop.presetId).objective);
+    assert.equal(new URL(page.url()).search, `?preset=${sop.presetId}`);
+    await page.locator('#workflow-objective').fill(sentinel);
+    // A repeated Astro event must not reset unsaved edits or install another listener.
+    await page.evaluate(() => document.dispatchEvent(new Event('astro:page-load')));
+    assert.equal(await page.locator('#workflow-objective').inputValue(), sentinel);
+    assert.ok(!page.url().includes(sentinel));
+    await page.getByRole('link', { name: 'Department SOP library', exact: true }).click();
+    await page.waitForURL(origin + '/sops/');
+  }
+  await page.goto(origin + '/workflow-planner/?preset=customer-success-escalation&objective=URL_INPUT_MUST_NOT_LOAD&unknown=discard');
+  await page.waitForFunction(() => !document.querySelector('#workflow-template').disabled);
+  assert.equal(new URL(page.url()).search, '?preset=customer-success-escalation');
+  assert.equal(await page.locator('#workflow-objective').inputValue(), getWorkflowTemplate('customer-success-escalation').objective);
+  await page.locator('#workflow-objective').fill(sentinel);
+  await page.locator('#workflow-template').selectOption('recruiting-question-pack');
+  page.once('dialog', dialog => dialog.dismiss());
+  await page.getByRole('button', { name: 'Load template', exact: true }).click();
+  assert.equal(await page.locator('#workflow-objective').inputValue(), sentinel);
+  assert.equal(new URL(page.url()).search, '?preset=customer-success-escalation');
+  page.once('dialog', dialog => dialog.accept());
+  await page.getByRole('button', { name: 'Load template', exact: true }).click();
+  assert.equal(await page.locator('#workflow-objective').inputValue(), getWorkflowTemplate('recruiting-question-pack').objective);
+  assert.equal(new URL(page.url()).search, '?preset=recruiting-question-pack');
+  await page.locator('#workflow-objective').fill(sentinel);
+  await page.evaluate(() => Object.defineProperty(navigator, 'clipboard', { configurable: true, value: { writeText: async () => { throw new Error('Fixture denial'); } } }));
+  await page.getByRole('button', { name: 'Copy Markdown', exact: true }).click();
+  await page.waitForFunction(() => document.querySelector('.wp-draft-status').textContent.includes('Clipboard unavailable'));
+  const expected = await page.locator('.wp-markdown code').textContent();
+  const downloadPromise = page.waitForEvent('download');
+  await page.getByRole('button', { name: 'Download Markdown', exact: true }).click();
+  const download = await downloadPromise;
+  assert.equal(readFileSync(await download.path(), 'utf8'), expected);
+  assert.ok(expected.includes(sentinel) && expected.includes('Acceptance tests (not run)'));
+  assert.ok(!expected.includes('- [x]'));
+  await page.evaluate(() => { window.print = () => { window.__printRequested = true; }; });
+  await page.getByRole('button', { name: 'Print specification', exact: true }).click();
+  assert.ok(await page.evaluate(() => window.__printRequested));
+  assert.equal(await page.locator('.wp-planner form').count(), 0);
+  assert.ok(!(await page.evaluate(() => JSON.stringify({ local: { ...localStorage }, session: { ...sessionStorage }, analytics: window.dataLayer })) ).includes(sentinel));
+  page.once('dialog', dialog => dialog.dismiss());
+  await page.getByRole('button', { name: 'Clear all fields', exact: true }).click();
+  assert.equal(await page.locator('#workflow-objective').inputValue(), sentinel);
+  page.once('dialog', dialog => dialog.accept());
+  await page.getByRole('button', { name: 'Clear all fields', exact: true }).click();
+  assert.equal(await page.locator('#workflow-objective').inputValue(), '');
+  assert.ok(await page.getByRole('button', { name: 'Download Markdown', exact: true }).isDisabled());
+  assert.equal(new URL(page.url()).search, '');
+  await page.reload();
+  await page.waitForFunction(() => !document.querySelector('#workflow-template').disabled);
+  assert.equal(await page.locator('#workflow-objective').inputValue(), getWorkflowTemplate('weekly-research-brief').objective);
+  assert.ok(requests.every(request => !request.includes(sentinel)), 'entered text never appears in a network request');
+  assert.deepEqual(errors, []);
+  await page.close();
+});
+
+test('Library format/department filters and keyboard search discover the SOPs after client navigation', async () => {
+  const page = await context.newPage();
+  await page.goto(origin + '/library/');
+  await page.locator('select[name="kind"]').selectOption('SOP');
+  assert.equal(await page.locator('[data-library-item]:visible').count(), 6);
+  await page.locator('select[name="topic"]').selectOption('Recruiting');
+  assert.equal(await page.locator('[data-library-item]:visible').count(), 1);
+  await page.locator('[data-library-item]:visible a').click();
+  await page.waitForURL(origin + '/sops/recruiting-interview-scorecard/');
+  await page.keyboard.press('Meta+k');
+  await page.locator('input[role="combobox"]').fill('Sales quality checks');
+  await page.getByRole('option').first().waitFor();
+  await page.keyboard.press('ArrowDown');
+  await page.keyboard.press('Enter');
+  await page.waitForURL(origin + '/sops/sales-call-to-crm/#quality-checks');
+  await page.setViewportSize({ width: 320, height: 1000 });
+  await page.locator('.sop-layout details summary').click();
+  await page.locator('.sop-layout details a[href="#acceptance-tests"]').click();
+  assert.equal(await page.locator('.sop-layout details').getAttribute('open'), null);
+  assert.equal(new URL(page.url()).hash, '#acceptance-tests');
+  assert.deepEqual(errors, []);
+  await page.close();
+});

--- a/tests/sops.test.mjs
+++ b/tests/sops.test.mjs
@@ -1,0 +1,140 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { parse } from '@astrojs/compiler';
+import ts from 'typescript';
+import { loadTs } from './helpers/load-ts.mjs';
+
+const sops = loadTs(new URL('../src/lib/sops.ts', import.meta.url));
+const workflow = loadTs(new URL('../src/lib/workflow-plan.ts', import.meta.url));
+const downloads = loadTs(new URL('../src/pages/sops/[slug].md.ts', import.meta.url));
+const { SOP_LIBRARY, SOP_SECTIONS, SOP_STATUS, SOP_BOUNDARY, getSopSections, sopHref, sopDownloadHref, renderSopMarkdown } = sops;
+const read = path => readFileSync(new URL(path, import.meta.url), 'utf8');
+
+test('six unique canonical SOP routes have substantive departmental contracts and aligned presets', () => {
+  assert.deepEqual(SOP_LIBRARY.map(sop => sop.slug), [
+    'sales-call-to-crm', 'marketing-content-review', 'operations-intelligence-brief',
+    'customer-success-escalation', 'recruiting-interview-scorecard', 'ai-agent-execution',
+  ]);
+  assert.equal(new Set(SOP_LIBRARY.map(sopHref)).size, 6);
+  assert.equal(new Set(SOP_LIBRARY.map(sopDownloadHref)).size, 6);
+  assert.equal(new Set(SOP_LIBRARY.map(sop => sop.presetId)).size, 6);
+  assert.deepEqual(SOP_LIBRARY.slice(0, 3).map(sop => sop.presetId), ['call-to-crm-follow-up', 'content-review', 'weekly-research-brief']);
+  for (const sop of SOP_LIBRARY) {
+    assert.match(sopHref(sop), /^\/sops\/[a-z0-9-]+\/$/);
+    assert.equal(sop.steps.length, 6);
+    assert.ok(sop.inputs.length >= 4 && sop.outputs.length >= 4 && sop.qualityChecks.length >= 4 && sop.acceptanceTests.length >= 4);
+    assert.ok(sop.owner && sop.reviewer && sop.trigger && sop.stopRecovery.length >= 3);
+    assert.ok(renderSopMarkdown(sop).split(/\s+/).length >= 600, sop.slug);
+    assert.deepEqual(workflow.validateWorkflowDraft(workflow.getWorkflowTemplate(sop.presetId)), []);
+  }
+  assert.ok(workflow.WORKFLOW_TEMPLATES.some(item => item.id === 'outbound-campaign-qa'));
+});
+
+test('the real Astro static paths and Markdown endpoint use the same six source records', async () => {
+  const { ast } = await parse(read('../src/pages/sops/[slug].astro'));
+  const frontmatter = ast.children.find(node => node.type === 'frontmatter').value;
+  const tree = ts.createSourceFile('page.ts', frontmatter, ts.ScriptTarget.Latest, true);
+  const paths = tree.statements.find(statement => ts.isVariableStatement(statement) && statement.declarationList.declarations.some(declaration => declaration.name.getText(tree) === 'getStaticPaths'));
+  const compiled = ts.transpileModule(paths.getText(tree), { compilerOptions: { module: ts.ModuleKind.CommonJS } }).outputText;
+  const exports = {};
+  new Function('SOP_LIBRARY', 'exports', compiled)(SOP_LIBRARY, exports);
+  assert.deepEqual(exports.getStaticPaths(), downloads.getStaticPaths());
+  for (const { params, props } of downloads.getStaticPaths()) {
+    const response = downloads.GET({ params, props });
+    assert.equal(response.status, 200);
+    assert.equal(response.headers.get('content-type'), 'text/markdown; charset=utf-8');
+    assert.equal(response.headers.get('content-disposition'), `attachment; filename="${params.slug}.md"`);
+    assert.equal(await response.text(), renderSopMarkdown(props.sop));
+  }
+});
+
+test('every rendered section item comes from the same content as its Markdown download', () => {
+  const page = read('../src/pages/sops/[slug].astro');
+  assert.match(page, /const sections = getSopSections\(sop\)/);
+  assert.match(page, /data-sop-content>\{item\}/);
+  assert.match(page, /id=\{section.id\}/);
+  assert.ok(!page.includes('set:html'), 'content is escaped by Astro, not injected as raw HTML');
+  for (const original of SOP_LIBRARY) {
+    const sop = { ...original, steps: [...original.steps, 'SOURCE PARITY SENTINEL'] };
+    const sections = getSopSections(sop);
+    assert.deepEqual(sections.map(section => section.id), SOP_SECTIONS.map(section => section.id));
+    for (const section of sections) for (const item of section.items) assert.ok(renderSopMarkdown(sop).includes(item), item);
+    assert.ok(sections.find(section => section.id === 'procedure').items.includes('SOURCE PARITY SENTINEL'));
+    assert.ok(renderSopMarkdown(sop).includes('SOURCE PARITY SENTINEL'));
+  }
+});
+
+test('downloaded Markdown links work without a website base and identify the canonical source SOP', () => {
+  const origin = 'https://dive.vladyslavpodoliako.com';
+  for (const sop of SOP_LIBRARY) {
+    const md = renderSopMarkdown(sop);
+    assert.ok(md.includes(`Source: [Canonical SOP](${origin}${sopHref(sop)})`));
+    const links = [...md.matchAll(/\[[^\]]+\]\(([^)]+)\)/g)].map(match => match[1]);
+    assert.deepEqual(links, [
+      `${origin}${sopHref(sop)}`, `${origin}/sops/`,
+      `${origin}/workflow-planner/?preset=${sop.presetId}`,
+    ]);
+    for (const href of links) {
+      assert.equal(new URL(href).origin, origin);
+      assert.equal(new URL(href).protocol, 'https:');
+    }
+    assert.doesNotMatch(md, /\]\(\/(?!\/)/, 'no root-relative links in an offline export');
+  }
+});
+
+test('all procedure steps and checks are explicitly unrun with no completed results or implied approval', () => {
+  for (const sop of SOP_LIBRARY) {
+    const md = renderSopMarkdown(sop);
+    assert.ok(md.includes(SOP_STATUS) && md.includes(SOP_BOUNDARY));
+    assert.doesNotMatch(md, /\[[xX]\]|\b(?:PASSED|COMPLETED|APPROVED)\b/);
+    assert.equal((md.match(/\[ \] Not run:/g) || []).length, sop.steps.length + sop.qualityChecks.length + sop.acceptanceTests.length);
+    assert.match(md, /Run status: Not run/);
+    assert.match(md, /Human decision: pending/);
+    assert.match(md, /Named person: not assigned/);
+    assert.match(md, /Expected results above are not observations/);
+    assert.equal(md, renderSopMarkdown(sop), 'deterministic export');
+    assert.ok(md.endsWith('\n') && !md.endsWith('\n\n'));
+  }
+});
+
+test('recruiting is a role-only question pack with no filled scorecard or decision surface', () => {
+  const sop = SOP_LIBRARY.find(sop => sop.department === 'Recruiting');
+  const md = renderSopMarkdown(sop);
+  assert.match(md, /Candidate records are not permitted inputs/);
+  assert.match(md, /does not score, rank, profile, reject, select, or make hiring decisions/);
+  assert.match(md, /No resumes, applicant records, interview transcripts/);
+  assert.match(md, /evidence sheet is blank and contains no ratings or recommendations/);
+  assert.match(md, /Processing stops and requests role-only inputs/);
+  assert.doesNotMatch(md, /\|\s*(?:Candidate|Score|Rank)\s*\||\b[1-5]\/5\b/);
+});
+
+test('preset URLs allow only one exact known ID and reject unknown, duplicated, or injected options', () => {
+  for (const { id } of workflow.WORKFLOW_TEMPLATES) {
+    assert.deepEqual(workflow.parseWorkflowPreset(`?preset=${id}`), { presetId: id, search: `?preset=${id}`, rejected: false });
+    assert.equal(workflow.workflowPresetHref(id, '/book/'), `/book/workflow-planner/?preset=${id}`);
+    const url = new URL(workflow.workflowPresetHref(id), 'https://example.test');
+    assert.deepEqual([...url.searchParams.keys()], ['preset']);
+    const malicious = workflow.parseWorkflowPreset(`?preset=${id}&objective=PRIVATE_SENTINEL&owner=secret`);
+    assert.equal(malicious.presetId, id);
+    assert.equal(malicious.search, `?preset=${id}`);
+    assert.ok(malicious.rejected);
+  }
+  for (const query of ['?preset=unknown', '?preset=', '?preset=__proto__', '?preset=content-review&preset=content-review', '?preset=content-review&preset=unknown', '?preset=CONTENT-REVIEW', '?preset=%3Cscript%3E', '?preset=content-review%00', '?objective=PRIVATE_SENTINEL', '?Preset=content-review', '?preset[]=content-review']) {
+    const result = workflow.parseWorkflowPreset(query);
+    assert.deepEqual(result, { presetId: 'weekly-research-brief', search: '', rejected: true }, query);
+  }
+  assert.deepEqual(workflow.parseWorkflowPreset(''), { presetId: 'weekly-research-brief', search: '', rejected: false });
+  assert.equal(workflow.parseWorkflowPreset('?preset=%63ontent-review').search, '?preset=content-review');
+  assert.throws(() => workflow.workflowPresetHref('unknown'), /Unknown workflow preset/);
+});
+
+test('Edition 14.3 is latest and owns the only banner; home and Chapter 11 link to the library', () => {
+  const { CHANGELOG } = loadTs(new URL('../src/lib/changelog.ts', import.meta.url));
+  assert.equal(CHANGELOG[0].edition, 'Edition 14.3');
+  assert.equal(CHANGELOG[0].date, '2026-09-05');
+  assert.equal(CHANGELOG[0].bannerHref, '/sops/');
+  assert.equal(CHANGELOG.filter(entry => entry.bannerText || entry.bannerHref).length, 1);
+  assert.ok(read('../src/pages/index.astro').includes('href={`${base}/sops/`} class="card'));
+  assert.match(read('../src/content/chapters/11-build-a-skill.mdx'), /<Callout[^>]*>[\s\S]*?\[AI SOP library\]\(\/sops\/\)[\s\S]*?<\/Callout>/);
+});

--- a/tests/workflow-plan.test.mjs
+++ b/tests/workflow-plan.test.mjs
@@ -18,11 +18,12 @@ const {
 
 const firstDraft = () => getWorkflowTemplate('weekly-research-brief');
 
-test('the four requested templates have unique IDs and complete, distinct requirements', () => {
+test('the four original and three new templates have unique IDs and complete, distinct requirements', () => {
   assert.deepEqual(WORKFLOW_TEMPLATES.map(({ id }) => id), [
     'weekly-research-brief', 'call-to-crm-follow-up', 'content-review', 'outbound-campaign-qa',
+    'customer-success-escalation', 'recruiting-question-pack', 'bounded-agent-trial',
   ]);
-  assert.equal(new Set(WORKFLOW_TEMPLATES.map(({ draft }) => draft.objective)).size, 4);
+  assert.equal(new Set(WORKFLOW_TEMPLATES.map(({ draft }) => draft.objective)).size, 7);
   for (const template of WORKFLOW_TEMPLATES) {
     assert.deepEqual(validateWorkflowDraft(template.draft), [], template.id);
     for (const key of ['inputs', 'allowedOutputs', 'approvalBoundaries', 'acceptanceTests']) {
@@ -185,7 +186,7 @@ test('the widget server-renders a readable draft, labeled fields, and disabled p
   const html = renderToStaticMarkup(createElement(exports.default));
   assert.match(html, /ph-no-capture ph-sensitive/);
   assert.match(html, /<fieldset[^>]*disabled=""/);
-  assert.equal((html.match(/<option /g) || []).length, 4);
+  assert.equal((html.match(/<option /g) || []).length, 7);
   assert.equal((html.match(/required=""/g) || []).length, 7);
   for (const { key } of WORKFLOW_FIELDS) {
     assert.ok(html.includes(`for="workflow-${key}"`), key);

--- a/tests/workflow-planner-navigation.test.mjs
+++ b/tests/workflow-planner-navigation.test.mjs
@@ -26,7 +26,7 @@ function harness(path = '/book/workflow-planner/?preset=content-review') {
   const historyState = { index: 3, astroMetadata: 'preserve' };
   const navigate = href => { window.location = new URL(href, 'https://example.test'); };
   navigate(path);
-  window.history = { state: historyState, replaceState: (value, title, href) => { writes.push({ value, href }); navigate(href); } };
+  window.history = { state: historyState, replaceState: (value, _title, href) => { writes.push({ value, href }); navigate(href); } };
   const context = {
     window, document, ...workflow, baseline: { current: null }, revision: { current: 0 }, loadedSearch: { current: null },
     setTemplateId: value => { state.preset = value; }, setDraft: value => { state.draft = value; },

--- a/tests/workflow-planner-navigation.test.mjs
+++ b/tests/workflow-planner-navigation.test.mjs
@@ -1,0 +1,71 @@
+import assert from 'node:assert/strict';
+import { getEventListeners } from 'node:events';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+import { runInNewContext } from 'node:vm';
+import ts from 'typescript';
+import { loadTs } from './helpers/load-ts.mjs';
+
+const source = readFileSync(new URL('../src/widgets/WorkflowPlanner.tsx', import.meta.url), 'utf8');
+const tree = ts.createSourceFile('WorkflowPlanner.tsx', source, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX);
+let effect;
+const visit = node => {
+  if (ts.isCallExpression(node) && node.expression.getText(tree) === 'useEffect' && node.arguments[0].getText(tree).includes('restorePreset')) effect = node.arguments[0];
+  ts.forEachChild(node, visit);
+};
+visit(tree);
+assert.ok(effect);
+const compiled = ts.transpileModule(`globalThis.mount = ${effect.getText(tree)};`, { compilerOptions: { target: ts.ScriptTarget.ES2022 } }).outputText;
+const workflow = loadTs(new URL('../src/lib/workflow-plan.ts', import.meta.url));
+
+function harness(path = '/book/workflow-planner/?preset=content-review') {
+  const window = new EventTarget();
+  const document = new EventTarget();
+  const state = { draft: null, preset: null, hydrated: false, notice: '' };
+  const writes = [];
+  const historyState = { index: 3, astroMetadata: 'preserve' };
+  const navigate = href => { window.location = new URL(href, 'https://example.test'); };
+  navigate(path);
+  window.history = { state: historyState, replaceState: (value, title, href) => { writes.push({ value, href }); navigate(href); } };
+  const context = {
+    window, document, ...workflow, baseline: { current: null }, revision: { current: 0 }, loadedSearch: { current: null },
+    setTemplateId: value => { state.preset = value; }, setDraft: value => { state.draft = value; },
+    setNotice: value => { state.notice = value; }, setHydrated: value => { state.hydrated = value; },
+  };
+  runInNewContext(compiled, context);
+  const cleanup = context.mount();
+  return { window, document, state, writes, historyState, navigate, cleanup };
+}
+test('cross-route Back preserves destination Library filters before the planner unmounts', () => {
+  const h = harness();
+  const draft = h.state.draft;
+  h.navigate('/book/library/?q=Fable&kind=Chapter&topic=Team%20%2B%20Tier');
+  h.window.dispatchEvent(new Event('popstate'));
+  h.document.dispatchEvent(new Event('astro:page-load'));
+  assert.equal(h.window.location.search, '?q=Fable&kind=Chapter&topic=Team%20%2B%20Tier');
+  assert.deepEqual(h.writes, []);
+  assert.equal(h.state.draft, draft);
+  h.cleanup();
+});
+test('preset changes on the same planner path restore once and clean up listeners', () => {
+  const h = harness();
+  h.navigate('/book/workflow-planner/?preset=recruiting-question-pack');
+  h.window.dispatchEvent(new Event('popstate'));
+  assert.equal(h.state.preset, 'recruiting-question-pack');
+  assert.equal(h.state.draft.objective, workflow.getWorkflowTemplate('recruiting-question-pack').objective);
+  h.state.draft.objective = 'UNSAVED SYNTHETIC FIXTURE';
+  h.document.dispatchEvent(new Event('astro:page-load'));
+  assert.equal(h.state.draft.objective, 'UNSAVED SYNTHETIC FIXTURE');
+  h.cleanup();
+  assert.equal(getEventListeners(h.window, 'popstate').length, 0);
+  assert.equal(getEventListeners(h.document, 'astro:page-load').length, 0);
+});
+test('planner-only URL sanitization preserves Astro history state and ignores supplied fields', () => {
+  const h = harness('/workflow-planner/?preset=content-review&owner=SYNTHETIC#workflow-preview');
+  assert.equal(h.window.location.search, '?preset=content-review');
+  assert.equal(h.window.location.hash, '#workflow-preview');
+  assert.equal(h.writes[0].value, h.historyState);
+  assert.equal(h.state.draft.owner, workflow.getWorkflowTemplate('content-review').owner);
+  assert.match(h.state.notice, /Unsupported URL options/);
+  h.cleanup();
+});


### PR DESCRIPTION
## Summary

Add six indexable departmental SOP templates, an index, matching single-source Markdown downloads, and deep links into the existing deterministic workflow planner. Reuse three presets and add customer success, role-only interview preparation, and bounded agent trial planning. Keep outbound campaign QA separate.

Templates are explicitly untested, general-purpose drafts. No company-data result, actual Belkins SOP, model execution, hiring decision, send, or new automation is claimed or performed.

Closes #24

## Verification

- Local Node 26.3.0: all 178 unit/regression tests passed after rebase and review corrections. Production build: 202 pages, 200 sitemap URLs, 206 rendered HTML target files; all postbuild gates passed.
- Build validates SEO, canonical URLs, sitemap inclusion, rendered links, fragment targets, and nested anchors.
- All six downloads use the same content as the HTML and absolute canonical links for offline use.
- Parent browser screenshots inspected for the index and all six procedures across 320, 390, 768, and 1440 widths, including light/dark variants. Mobile section-drawer closure verified after client navigation; no document-wide overflow in checked states.
- Final planner confirmation and Back-navigation browser checks are pending because the host Mac locked during QA. Do not merge until that gate is completed or explicitly recorded as blocked.
- The opt-in browser suite was authored; its earlier run passed 3/4 before the shared navigation correction. It is not represented as fully passing. New lifecycle unit regressions cover the correction; parent browser checks verified drawer closure afterward.
- Existing six stale-number ledger warnings and 42 Astro hints are unchanged.

## Reviewer notes

Pre-PR review covers scope, simplicity, test quality, security of URL/user-input boundaries, and content/evidence limits.

- Downloaded Markdown now identifies the canonical SOP and uses absolute links.
- SectionNav now binds on Astro navigation, removes stale listeners/observers, closes its own drawer independently of IntersectionObserver, and exposes aria-current. Regression tests cover repeated loads and disposal.
- The planner's popstate handler now exits when the pathname is no longer its mounted route, preserving Library filters during Back navigation. Regression tests execute the actual effect and check cross-route Back, same-route preset changes, cleanup, and history metadata preservation.
- No deployment, auth, analytics, secrets, pricing data, or lockfiles changed. The research chapters in Edition 14.2 remain intact under the latest-only Edition 14.3 banner.
